### PR TITLE
Ignore properties if they are present but their value is undefined

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -397,7 +397,7 @@ export function makeObject<
     for (const index of Object.keys(props)) {
       let maker: any = props[index];
       if (maker.optional) {
-        if (!(index in value)) {
+        if (!(index in value) || value[index] === undefined) {
           continue;
         }
         maker = maker.optional;

--- a/test/runtime.spec.ts
+++ b/test/runtime.spec.ts
@@ -176,6 +176,11 @@ describe('makeObject', () => {
     const fun = oar.makeObject({ a: oar.makeNumber() }, oar.makeString());
     expect(fun({ a: 1 }).success()).toEqual({ a: 1 });
   });
+
+  it('allows undefined props', () => {
+    const fun = oar.makeObject({ a: oar.makeOptional(oar.makeNumber()) });
+    expect(fun({ a: undefined }).success()).toEqual({});
+  });
 });
 
 describe('ValueClass', () => {


### PR DESCRIPTION
Currently an error is thrown if an object with an optional property is created with that property as `undefined`.

With this PR, the property will be ignored if its missing (old behaviour) or if the value is undefined.