### PR TITLE
expose client sent headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ const spec: api.Endpoints = {
     }
   },
   "/item/{id}": {
+    delete: async ctx => {
+      delete values[ctx.params.id];
+      return runtime.text(204, '');
+    },
     get: async ctx => {
       const item = values[ctx.params.id];
       if (item) {
@@ -67,33 +71,43 @@ export function createApp() {
 import * as api from "../tmp/client.generated";
 import { client } from "../index";
 import * as app from "./server";
+import * as assert from "assert";
 
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(client.axiosAdapter);
 async function runClient() {
-  try {
-      const posted = await apiClient.item.post({
-          headers: {
-              authorization: 'Bearer ^-^'
-          },
-          body: client.json({ id: "id", name: "name" })
+    const posted = await apiClient.item.post({
+        headers: {
+            authorization: 'Bearer ^-^'
+        },
+        body: client.json({ id: "id", name: "name" })
     });
-    if (posted.status === 201) {
-      const got = await apiClient.item(posted.value.value.id).get();
-      if (got.status === 200 && got.value.value.id === "id") {
-        process.exit(0);
-      }
+    if (posted.status !== 201) {
+        return assert.fail('wrong response');
     }
-  } catch (e) {
-      console.log('Got error', e);
-  }
-  process.exit(1);
+    const stored = await apiClient.item(posted.value.value.id).get();
+    if (stored.status !== 200) {
+        return assert.fail('wrong response');
+    }
+    assert(stored.value.value.id === 'id');
+
+    const  deleted = await apiClient.item(posted.value.value.id).delete();
+    assert(deleted.status === 204);
+    return;
 }
 
 // spin up the server
 const port = 12000;
-app.createApp().listen(port, runClient);
+app.createApp().listen(port, async () => {
+    try {
+        await runClient();
+        process.exit(0);
+    } catch(e) {
+        console.log(e);
+        process.exit(1);
+    }
+});
 
 ```
 
@@ -120,7 +134,7 @@ driver.generate({
   header: "/* tslint:disable variable-name only-arrow-functions*/",
   openapiFilePath: "./test/example.yaml",
   // Omit error responses  from the client response types
-  emitStatusCode: (code: number) => [200, 201].indexOf(code) >= 0
+  emitStatusCode: (code: number) => [200, 201, 204].indexOf(code) >= 0
 });
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ const values: { [key: string]: types.Item } = {};
 const spec: api.Endpoints = {
   "/item": {
     post: async ctx => {
+      if (ctx.headers.authorization !== 'Bearer ^-^') {
+          return runtime.json(403, { message: 'Unauthorized'})
+      }
       values[ctx.body.value.id] = types.Item.make({
         id: ctx.body.value.id,
         name: ctx.body.value.name
@@ -70,16 +73,21 @@ import * as app from "./server";
 const apiClient = api.client(client.axiosAdapter);
 async function runClient() {
   try {
-    const posted = await apiClient.item.post({
-      body: client.json({ id: "id", name: "name" })
+      const posted = await apiClient.item.post({
+          headers: {
+              authorization: 'Bearer ^-^'
+          },
+          body: client.json({ id: "id", name: "name" })
     });
     if (posted.status === 201) {
-      const got = await apiClient.item(posted.value.value.id).get({});
+      const got = await apiClient.item(posted.value.value.id).get();
       if (got.status === 200 && got.value.value.id === "id") {
         process.exit(0);
       }
     }
-  } catch (e) {}
+  } catch (e) {
+      console.log('Got error', e);
+  }
   process.exit(1);
 }
 

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -8,16 +8,21 @@ import * as app from "./server";
 const apiClient = api.client(client.axiosAdapter);
 async function runClient() {
   try {
-    const posted = await apiClient.item.post({
-      body: client.json({ id: "id", name: "name" })
+      const posted = await apiClient.item.post({
+          headers: {
+              authorization: 'Bearer ^-^'
+          },
+          body: client.json({ id: "id", name: "name" })
     });
     if (posted.status === 201) {
-      const got = await apiClient.item(posted.value.value.id).get({});
+      const got = await apiClient.item(posted.value.value.id).get();
       if (got.status === 200 && got.value.value.id === "id") {
         process.exit(0);
       }
     }
-  } catch (e) {}
+  } catch (e) {
+      console.log('Got error', e);
+  }
   process.exit(1);
 }
 

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -2,30 +2,40 @@
 import * as api from "../tmp/client.generated";
 import { client } from "../index";
 import * as app from "./server";
+import * as assert from "assert";
 
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(client.axiosAdapter);
 async function runClient() {
-  try {
-      const posted = await apiClient.item.post({
-          headers: {
-              authorization: 'Bearer ^-^'
-          },
-          body: client.json({ id: "id", name: "name" })
+    const posted = await apiClient.item.post({
+        headers: {
+            authorization: 'Bearer ^-^'
+        },
+        body: client.json({ id: "id", name: "name" })
     });
-    if (posted.status === 201) {
-      const got = await apiClient.item(posted.value.value.id).get();
-      if (got.status === 200 && got.value.value.id === "id") {
-        process.exit(0);
-      }
+    if (posted.status !== 201) {
+        return assert.fail('wrong response');
     }
-  } catch (e) {
-      console.log('Got error', e);
-  }
-  process.exit(1);
+    const stored = await apiClient.item(posted.value.value.id).get();
+    if (stored.status !== 200) {
+        return assert.fail('wrong response');
+    }
+    assert(stored.value.value.id === 'id');
+
+    const  deleted = await apiClient.item(posted.value.value.id).delete();
+    assert(deleted.status === 204);
+    return;
 }
 
 // spin up the server
 const port = 12000;
-app.createApp().listen(port, runClient);
+app.createApp().listen(port, async () => {
+    try {
+        await runClient();
+        process.exit(0);
+    } catch(e) {
+        console.log(e);
+        process.exit(1);
+    }
+});

--- a/examples/driver.ts
+++ b/examples/driver.ts
@@ -18,5 +18,5 @@ driver.generate({
   header: "/* tslint:disable variable-name only-arrow-functions*/",
   openapiFilePath: "./test/example.yaml",
   // Omit error responses  from the client response types
-  emitStatusCode: (code: number) => [200, 201].indexOf(code) >= 0
+  emitStatusCode: (code: number) => [200, 201, 204].indexOf(code) >= 0
 });

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -12,6 +12,9 @@ const values: { [key: string]: types.Item } = {};
 const spec: api.Endpoints = {
   "/item": {
     post: async ctx => {
+      if (ctx.headers.authorization !== 'Bearer ^-^') {
+          return runtime.json(403, { message: 'Unauthorized'})
+      }
       values[ctx.body.value.id] = types.Item.make({
         id: ctx.body.value.id,
         name: ctx.body.value.name

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -23,6 +23,10 @@ const spec: api.Endpoints = {
     }
   },
   "/item/{id}": {
+    delete: async ctx => {
+      delete values[ctx.params.id];
+      return runtime.text(204, '');
+    },
     get: async ctx => {
       const item = values[ctx.params.id];
       if (item) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.5.0-beta.3",
+  "version": "1.5.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.5.0",
+  "version": "1.5.0-beta.3",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.5.0",
+  "version": "1.5.0-beta.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import * as server from './server';
 import * as assert from 'assert';
 import safe from '@smartlyio/safe-navigation';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import * as runtime from './runtime';
 import * as FormData from 'form-data';
 
@@ -85,6 +85,21 @@ function axiosToJson(data: any) {
   return data;
 }
 
+function getContentType(response: AxiosResponse<any>) {
+  if (response.status === 204) {
+    return 'text/plain';
+  }
+  const type = response.headers['content-type'];
+  return type.split(';')[0].trim();
+}
+
+function getResponseData(response: AxiosResponse<any>) {
+  if (response.status === 204) {
+    return '';
+  }
+  return response.data;
+}
+
 export const axiosAdapter: ClientAdapter = async (
   arg: server.EndpointArg<any, any, any, any>
 ): Promise<any> => {
@@ -107,8 +122,8 @@ export const axiosAdapter: ClientAdapter = async (
   return {
     status: response.status,
     value: {
-      contentType: 'application/json',
-      value: response.data
+      contentType: getContentType(response),
+      value: getResponseData(response)
     }
   };
 };
@@ -243,7 +258,7 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
       servers: handler.servers,
       method: handler.method,
       params,
-      headers: safe(ctx ).headers.$,
+      headers: safe(ctx).headers.$,
       query: safe(ctx).query.$,
       body: safe(ctx).body.$
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,7 +7,7 @@ import * as FormData from 'form-data';
 
 type HeaderProp<H, Next> = H extends void ? Next : { headers: H } & Next;
 type QueryProp<Q, Next> = Q extends void ? Next : { query: Q } & Next;
-type BodyProp<B> = B extends void ? void : { body: B };
+type BodyProp<B> = B extends void ? {} : { body: B };
 
 export type ClientArg<
   H extends server.Headers | void,
@@ -20,7 +20,7 @@ export type ClientEndpoint<
   Q extends server.Query | void,
   B extends server.RequestBody<any> | void,
   R extends server.Response<number, any, any>
-> = ClientArg<H, Q, B> extends void ? () => Promise<R> : (ctx: ClientArg<H, Q, B>) => Promise<R>;
+> = {} extends ClientArg<H, Q, B> ? () => Promise<R> : (ctx: ClientArg<H, Q, B>) => Promise<R>;
 
 type PathParam = (param: string) => ClientSpec | ClientEndpoint<any, any, any, any>;
 export interface ClientSpec {

--- a/src/client.ts
+++ b/src/client.ts
@@ -95,7 +95,7 @@ export const axiosAdapter: ClientAdapter = async (
   const params = axiosToJson(arg.query);
   const data = toAxiosData(arg.body);
   const url = server + arg.path;
-  const headers = arg.headers;
+  const headers = { ...arg.headers, ...(data instanceof FormData ? data.getHeaders() : {}) };
   const response = await axios.request({
     method: arg.method,
     headers,
@@ -243,9 +243,9 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
       servers: handler.servers,
       method: handler.method,
       params,
-      headers: ((ctx || {}) as { headers?: any }).headers,
-      query: ((ctx || {}) as { query?: any }).query,
-      body: ((ctx || {}) as { body?: any }).body
+      headers: safe(ctx ).headers.$,
+      query: safe(ctx).query.$,
+      body: safe(ctx).body.$
     });
 }
 

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -149,6 +149,7 @@ function generateParameterType(
   }
   const jointSchema: oas.SchemaObject = {
     type: 'object',
+    additionalProperties: false,
     required: pathParams.map(param => param.name),
     properties: pathParams.reduce((memo: any, param) => {
       memo[normalize(param.name)] = param.schema;

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -130,30 +130,28 @@ function generateQueryType(
 }
 
 function generateParameterType(
+  type: 'path' | 'header',
   op: string,
   paramSchema: undefined | ReadonlyArray<oas.ParameterObject | oas.ReferenceObject>,
-  oasSchema: oas.OpenAPIObject
+  oasSchema: oas.OpenAPIObject,
+  normalize = (name: string) => name
 ) {
+  const empty = generateTopLevelType(op, { type: 'void' });
   if (!paramSchema) {
-    return generateTopLevelType(op, {
-      type: 'void'
-    });
+    return empty;
   }
   const schema = oautil.deref(paramSchema, oasSchema);
   const pathParams = schema
     .map(schema => oautil.deref(schema, oasSchema))
-    .filter(schema => schema.in === 'path');
+    .filter(schema => schema.in === type);
   if (pathParams.length === 0) {
-    return generateTopLevelType(op, {
-      type: 'void'
-    });
+    return empty;
   }
   const jointSchema: oas.SchemaObject = {
     type: 'object',
-    additionalProperties: false,
     required: pathParams.map(param => param.name),
     properties: pathParams.reduce((memo: any, param) => {
-      memo[param.name] = param.schema;
+      memo[normalize(param.name)] = param.schema;
       return memo;
     }, {})
   };
@@ -305,9 +303,21 @@ function generateQueryTypes(opt: Options): ts.NodeArray<ts.Node> {
           )
         )
       );
+      oautil.errorTag(`in ${method.toUpperCase()} ${path} header`, () =>
+        response.push(
+          ...generateParameterType(
+            'header',
+            oautil.endpointTypeName(endpoint, path, method, 'headers'),
+            endpoint.parameters,
+            schema,
+            name => name.toLowerCase()
+          )
+        )
+      );
       oautil.errorTag(`in ${method.toUpperCase()} ${path} parameters`, () =>
         response.push(
           ...generateParameterType(
+            'path',
             oautil.endpointTypeName(endpoint, path, method, 'parameters'),
             endpoint.parameters,
             schema
@@ -446,6 +456,14 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
           'value',
           undefined,
           ts.createTypeReferenceNode('ShapeOf' + oautil.typenamify(key), [])
+        ),
+        ts.createParameter(
+          undefined,
+          undefined,
+          undefined,
+          'opts',
+          ts.createToken(ts.SyntaxKind.QuestionToken),
+          ts.createTypeReferenceNode(ts.createQualifiedName(klassifyLib, 'MakeOptions'), [])
         )
       ],
       undefined,
@@ -460,7 +478,8 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
               ts.createCall(
                 ts.createPropertyAccess(
                   ts.createCall(ts.createIdentifier('build' + oautil.typenamify(key)), undefined, [
-                    ts.createIdentifier('value')
+                    ts.createIdentifier('value'),
+                    ts.createIdentifier('opts')
                   ]),
                   ts.createIdentifier('success')
                 ),
@@ -487,6 +506,14 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
           'value',
           undefined,
           ts.createTypeReferenceNode('ShapeOf' + oautil.typenamify(key), [])
+        ),
+        ts.createParameter(
+          undefined,
+          undefined,
+          undefined,
+          'opts',
+          ts.createToken(ts.SyntaxKind.QuestionToken),
+          ts.createTypeReferenceNode(ts.createQualifiedName(klassifyLib, 'MakeOptions'), [])
         )
       ],
       ts.createTypeReferenceNode(fromLib(makeTypeTypeName), [
@@ -495,7 +522,8 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
       ts.createBlock([
         ts.createReturn(
           ts.createCall(ts.createIdentifier('make' + oautil.typenamify(key)), undefined, [
-            ts.createIdentifier('value')
+            ts.createIdentifier('value'),
+            ts.createIdentifier('opts')
           ])
         )
       ])

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,16 +119,13 @@ function voidify(value: {} | undefined | null) {
 
 function cleanHeaders<H>(maker: oar.Maker<any, H>, headers: {} | null | undefined) {
   const normalized = voidify(lowercaseObject(headers));
-  const made = maker(normalized, {
-    unknownField: 'drop'
-  });
-  if (made.isSuccess()) {
-    return made.success();
+  const acceptsNull = maker(null);
+  if (acceptsNull.isSuccess()) {
+    return acceptsNull.success();
   }
-  const maybeEmpty = oar
-    .makeObject({})(normalized, { unknownField: 'drop' })
-    .success(throwRequestValidationError.bind(null, 'headers'));
-  return maker(voidify(maybeEmpty)).success(throwRequestValidationError.bind(null, 'headers'));
+  return maker(normalized, {
+    unknownField: 'drop'
+  }).success(throwRequestValidationError.bind(null, 'headers'));
 }
 
 export function safe<

--- a/src/server.ts
+++ b/src/server.ts
@@ -99,7 +99,7 @@ function throwResponseValidationError(tag: string, originalValue: any, e: oar.Ma
   return null as any;
 }
 
-function lowercaseObject(o?: {} | undefined | null) {
+function lowercaseObject(o: {} | undefined | null): {} | null | undefined {
   if (o == null) {
     return o;
   }
@@ -117,7 +117,7 @@ function voidify(value: {} | undefined | null) {
   return null;
 }
 
-function cleanHeaders<H>(maker: oar.Maker<any, H>, headers: {} | null | undefined) {
+function cleanHeaders<H>(maker: oar.Maker<any, H>, headers: {}) {
   const normalized = voidify(lowercaseObject(headers));
   const acceptsNull = maker(null);
   if (acceptsNull.isSuccess()) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,7 +37,7 @@ export function errorTag<T>(tag: string, fn: () => T): T {
   }
 }
 
-type QueryTags = 'query' | 'parameters' | 'requestBody' | 'response' | 'response';
+type QueryTags = 'query' | 'parameters' | 'requestBody' | 'response' | 'response' | 'headers';
 export function endpointTypeName(
   op: oas.OperationObject,
   path: string,

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -35,6 +35,16 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /item/{id}:
+    delete:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
     get:
       parameters:
         - name: id
@@ -56,6 +66,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 components:
+  responses:
+    NoContent:
+      description: success but no content
+      content:
+        text/plain:
+          schema:
+            type: string
   schemas:
     Item:
       type: object

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -8,6 +8,13 @@ paths:
   /item:
     post:
       description: create an item
+      parameters:
+        - in: header
+          description: Bearer Auth
+          name: Authorization
+          required: true
+          schema:
+            type: string
       requestBody:
         required: true
         content:

--- a/test/runtime.spec.ts
+++ b/test/runtime.spec.ts
@@ -167,6 +167,11 @@ describe('makeArray', () => {
 });
 
 describe('makeObject', () => {
+  it ('drops unknown properties if told to', () => {
+    const fun = oar.makeObject({ a: oar.makeNumber() });
+    expect(fun({ a: 1, missing: 'a' }, { unknownField: 'drop'}).success()).toEqual({ a: 1 });
+  });
+
   it('allows additional props', () => {
     const fun = oar.makeObject({}, oar.makeString());
     expect(fun({ a: 'xxx' }).success()).toEqual({ a: 'xxx' });

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -3,7 +3,8 @@ import * as oar from '../src/runtime';
 
 describe('safe', () => {
   it('validates request and response', async () => {
-    const endpoint = server.safe<any, any, any, any>(
+    const endpoint = server.safe<any, any, any, any, any>(
+      oar.makeVoid(),
       oar.makeVoid(),
       oar.makeObject({ param: oar.makeNumber() }) as oar.Maker<any, any>,
       oar.makeVoid(),
@@ -24,6 +25,7 @@ describe('safe', () => {
       servers: ['https://example.com'],
       path: 'some/path',
       op: 'someOp',
+      headers: null as any,
       params: null as any,
       query: { param: 1 } as any,
       body: null as any


### PR DESCRIPTION
We expose only the headers specified in the oa spec. And to do that need to do
some hackery to lose all the other headers.