### PR TITLE
handle required path params correctly

### DIFF
--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -147,10 +147,17 @@ function generateParameterType(
   if (pathParams.length === 0) {
     return empty;
   }
+  const required: string[] = [];
+  pathParams.map(paramOrRef => {
+    const param = oautil.deref(paramOrRef, oasSchema);
+    if (param.required) {
+      required.push(normalize(param.name));
+    }
+  });
   const jointSchema: oas.SchemaObject = {
     type: 'object',
     additionalProperties: false,
-    required: pathParams.map(param => param.name),
+    required,
     properties: pathParams.reduce((memo: any, param) => {
       memo[normalize(param.name)] = param.schema;
       return memo;


### PR DESCRIPTION
now we use the normalized property name in the required list