### PR TITLE
Use deifininte assignment for class properties

### DIFF
--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -18,7 +18,7 @@ function generateClassMembers(
       [ts.createToken(ts.SyntaxKind.ReadonlyKeyword)],
       quotedProp(key),
       required && required.indexOf(key) >= 0
-        ? undefined
+        ? ts.createToken(ts.SyntaxKind.ExclamationToken)
         : ts.createToken(ts.SyntaxKind.QuestionToken),
       generateType(value),
       undefined


### PR DESCRIPTION
projects with `strictPropertyInitialization` fails for generated types because the properties are initialised inside the make helper. Using definite assignment tells TS that the property is initialised.
