### PR TITLE
do not convert request body into object if it's an array

### DIFF
--- a/adapters/koa/koa.ts
+++ b/adapters/koa/koa.ts
@@ -20,7 +20,8 @@ function adapter(router: Router): runtime.server.ServerAdapter {
         }, {});
       }
       const contentType = ctx.request.type;
-      const value = { ...(ctx.request as any).body, ...fileFields };
+      const requestBody = (ctx.request as any).body;
+      const value = Array.isArray(requestBody) ? requestBody : { ...requestBody, ...fileFields };
       const body = Object.keys(value).length > 0 ? { value, contentType } : undefined;
       const result = await handler({
         path,


### PR DESCRIPTION
If the request body is an array, it's converted into an object in the validation. Thus having an api endpoint like the following fails validation
```
content:
  application/json:
    schema:
    type: array
    items:
      $ref: '#/components/schemas/Item'
```
Workaround is to have something like the following, but wrapping the array into an object is kinda weird endpoint imho
```
content:
  application/json:
  schema:
    type: object
      properties:
        items:
          $ref: '#/components/schemas/Items'
        required:
          - items
```