### PR TITLE
Support request context for handlers in server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const spec: api.EndpointsWithContext<RequestContext> = {
       if (item) {
         return runtime.json(200, item);
       }
-      return runtime.json(400, { message: 'not found' });
+      return runtime.json(400, { message: 'not found', messageIndex: ctx.requestContext.messageIndex });
     }
   }
 };

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ interface RequestContext {
   messageIndex: number;
 }
 
-// 'api.Endpoints' is the generated type of the server
+// 'api.EndpointsWithContext' is the generated type of the server
 const spec: api.EndpointsWithContext<RequestContext> = {
   '/item': {
     post: async ctx => {
       if (ctx.headers.authorization !== 'Bearer ^-^') {
-        return runtime.json(403, { message: 'Unauthorized' });
+        return runtime.json(403, { message: 'Unauthorized', messageIndex: ctx.requestContext.messageIndex });
       }
       values[ctx.body.value.id] = common.Item.make({
         id: ctx.body.value.id,

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ import * as koaBody from 'koa-body';
 // setup a db :)
 const values: { [key: string]: common.Item } = {};
 
+interface RequestContext {
+  messageIndex: number;
+}
+
 // 'api.Endpoints' is the generated type of the server
-const spec: api.Endpoints = {
+const spec: api.EndpointsWithContext<RequestContext> = {
   '/item': {
     post: async ctx => {
       if (ctx.headers.authorization !== 'Bearer ^-^') {
@@ -45,9 +49,15 @@ const spec: api.Endpoints = {
   }
 };
 
+let index = 0;
+
 // 'koaAdapter.bind'  binds the endpoint implemantion in'spec' to
 // koa-router routes using a koa adapter
-const routes = koaAdapter.bind<api.Endpoints>(api.router, spec);
+const routes = koaAdapter.bind<api.EndpointsWithContext<RequestContext>, RequestContext>(
+  runtime.server.createHandlerFactory<api.EndpointsWithContext<RequestContext>>(api.endpointHandlers),
+  spec,
+  () => ({ messageIndex: index++ })
+);
 
 // finally we can create a Koa app from the routes
 export function createApp() {

--- a/adapters/koa/koa.ts
+++ b/adapters/koa/koa.ts
@@ -1,8 +1,11 @@
 import * as Router from 'koa-router';
-import * as Koa from 'koa';
+import { ParameterizedContext } from 'koa';
 import * as runtime from '@smartlyio/oats-runtime';
 
-function adapter(router: Router): runtime.server.ServerAdapter {
+function adapter<StateT, CustomT, RequestContext extends object>(
+  router: Router<StateT, CustomT>,
+  requestContextCreator: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext
+): runtime.server.ServerAdapter {
   return (
     path: string,
     op: string,
@@ -10,7 +13,7 @@ function adapter(router: Router): runtime.server.ServerAdapter {
     handler: runtime.server.SafeEndpoint
   ) => {
     const koaPath = path.replace(/{([^}]+)}/g, (m, param) => ':' + param);
-    (router as any)[method](koaPath, async (ctx: Koa.Context) => {
+    (router as any)[method](koaPath, async (ctx: ParameterizedContext<StateT, CustomT>) => {
       const files = (ctx as any).request.files;
       let fileFields = {};
       if (files) {
@@ -29,9 +32,10 @@ function adapter(router: Router): runtime.server.ServerAdapter {
         servers: [],
         op,
         headers: ctx.request.headers,
-        params: ctx.params,
+        params: (ctx as any).params,
         query: ctx.query,
-        body
+        body,
+        requestContext: requestContextCreator(ctx)
       });
       ctx.status = result.status;
       ctx.body = result.value.value;
@@ -39,8 +43,20 @@ function adapter(router: Router): runtime.server.ServerAdapter {
   };
 }
 
-export function bind<Spec>(handler: runtime.server.HandlerFactory<Spec>, spec: Spec): Router {
-  const router = new Router();
-  handler(adapter(router))(spec);
+/**
+ * Bind provided handlers for the OpenAPI routes
+ *
+ * Koa's default StateT and CustomT values are selected as defaults
+ * @param handler
+ * @param spec
+ * @param requestContextCreator
+ */
+export function bind<Spec, RequestContext = any, StateT = any, CustomT = {}>(
+  handler: runtime.server.HandlerFactory<Spec>,
+  spec: Spec,
+  requestContextCreator?: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext
+): Router<StateT, CustomT> {
+  const router = new Router<StateT, CustomT>();
+  handler(adapter(router, requestContextCreator || (() => ({}))))(spec);
   return router;
 }

--- a/adapters/koa/koa.ts
+++ b/adapters/koa/koa.ts
@@ -2,7 +2,7 @@ import * as Router from 'koa-router';
 import { ParameterizedContext } from 'koa';
 import * as runtime from '@smartlyio/oats-runtime';
 
-function adapter<StateT, CustomT, RequestContext extends object>(
+function adapter<StateT, CustomT, RequestContext>(
   router: Router<StateT, CustomT>,
   requestContextCreator: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext
 ): runtime.server.ServerAdapter {
@@ -51,7 +51,7 @@ function adapter<StateT, CustomT, RequestContext extends object>(
  * @param spec
  * @param requestContextCreator
  */
-export function bind<Spec, RequestContext = any, StateT = any, CustomT = {}>(
+export function bind<Spec, RequestContext = void, StateT = any, CustomT = {}>(
   handler: runtime.server.HandlerFactory<Spec>,
   spec: Spec,
   requestContextCreator?: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext

--- a/adapters/koa/package.json
+++ b/adapters/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-koa-adapter",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "license": "MIT",
   "description": "Koa adapter for Oats",
   "private": false,
@@ -16,13 +16,13 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "typescript": "^3.6.3",
+    "@smartlyio/oats-runtime": "^1.0.0",
     "@types/koa": "^2.0.39",
     "@types/koa-router": "^7.0.23",
     "koa": "^2.3.0",
     "koa-body": "^4.0.4",
     "koa-router": "^7.2.1",
-    "@smartlyio/oats-runtime": "^1.0.0"
+    "typescript": "^3.6.3"
   },
   "keywords": [
     "oats",

--- a/adapters/koa/package.json
+++ b/adapters/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-koa-adapter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "Koa adapter for Oats",
   "private": false,

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -13,7 +13,7 @@ interface RequestContext {
   messageIndex: number;
 }
 
-// 'api.Endpoints' is the generated type of the server
+// 'api.EndpointsWithContext' is the generated type of the server
 const spec: api.EndpointsWithContext<RequestContext> = {
   '/item': {
     post: async ctx => {
@@ -37,7 +37,7 @@ const spec: api.EndpointsWithContext<RequestContext> = {
       if (item) {
         return runtime.json(200, item);
       }
-      return runtime.json(400, { message: 'not found' });
+      return runtime.json(400, { message: 'not found', messageIndex: ctx.requestContext.messageIndex });
     }
   }
 };

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -9,8 +9,12 @@ import * as koaBody from 'koa-body';
 // setup a db :)
 const values: { [key: string]: common.Item } = {};
 
+interface RequestContext {
+  messageIndex: number;
+}
+
 // 'api.Endpoints' is the generated type of the server
-const spec: api.Endpoints = {
+const spec: api.EndpointsWithContext<RequestContext> = {
   '/item': {
     post: async ctx => {
       if (ctx.headers.authorization !== 'Bearer ^-^') {
@@ -38,9 +42,15 @@ const spec: api.Endpoints = {
   }
 };
 
+let index = 0;
+
 // 'koaAdapter.bind'  binds the endpoint implemantion in'spec' to
 // koa-router routes using a koa adapter
-const routes = koaAdapter.bind<api.Endpoints>(api.router, spec);
+const routes = koaAdapter.bind<api.EndpointsWithContext<RequestContext>, RequestContext>(
+  runtime.server.createHandlerFactory<api.EndpointsWithContext<RequestContext>>(api.endpointHandlers),
+  spec,
+  () => ({ messageIndex: index++ })
+);
 
 // finally we can create a Koa app from the routes
 export function createApp() {

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -18,7 +18,7 @@ const spec: api.EndpointsWithContext<RequestContext> = {
   '/item': {
     post: async ctx => {
       if (ctx.headers.authorization !== 'Bearer ^-^') {
-        return runtime.json(403, { message: 'Unauthorized' });
+        return runtime.json(403, { message: 'Unauthorized', messageIndex: ctx.requestContext.messageIndex });
       }
       values[ctx.body.value.id] = common.Item.make({
         id: ctx.body.value.id,

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   ],
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "^1.0.1",
-    "@smartlyio/oats-koa-adapter": "^1.0.1",
-    "@smartlyio/oats-runtime": "^1.0.3",
+    "@smartlyio/oats-koa-adapter": "^1.0.4",
+    "@smartlyio/oats-runtime": "^1.0.5",
     "@types/jest": "^24.0.18",
     "@types/koa": "^2.0.50",
     "@types/koa-mount": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/runtime/src/client.ts
+++ b/runtime/src/client.ts
@@ -185,7 +185,8 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
       params,
       headers: safe(ctx).headers.$,
       query: safe(ctx).query.$,
-      body: safe(ctx).body.$
+      body: safe(ctx).body.$,
+      requestContext: {}
     });
 }
 

--- a/runtime/test/server.spec.ts
+++ b/runtime/test/server.spec.ts
@@ -4,7 +4,7 @@ import { makeNumber, makeObject, Maker, makeString, makeVoid } from '../src/make
 
 describe('safe', () => {
   it('validates request and response', async () => {
-    const endpoint = server.safe<any, any, any, any, any>(
+    const endpoint = server.safe<any, any, any, any, any, any>(
       makeVoid(),
       makeVoid(),
       makeObject({ param: makeNumber() }) as Maker<any, any>,
@@ -29,7 +29,8 @@ describe('safe', () => {
       headers: null as any,
       params: null as any,
       query: { param: 1 } as any,
-      body: null as any
+      body: null as any,
+      requestContext: {}
     });
     expect(response.status).toEqual(200);
     expect(response.value.value).toEqual('response');

--- a/src/generate-server.ts
+++ b/src/generate-server.ts
@@ -84,7 +84,8 @@ function generateMethod<S extends oas.OperationObject, K extends keyof S>(
     params,
     query,
     body,
-    response
+    response,
+    ts.createTypeReferenceNode('RequestContext', undefined)
   ]);
 }
 
@@ -246,10 +247,19 @@ function generateEndpointsType(opts: Options) {
     ts.createInterfaceDeclaration(
       undefined,
       [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
-      'Endpoints',
-      undefined,
+      'EndpointsWithContext',
+      [ts.createTypeParameterDeclaration('RequestContext', undefined, undefined)],
       undefined,
       members
+    ),
+    ts.createTypeAliasDeclaration(
+      undefined,
+      [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
+      'Endpoints',
+      undefined,
+      ts.createTypeReferenceNode('EndpointsWithContext', [
+        ts.createTypeReferenceNode('void', undefined)
+      ])
     )
   ]);
 }
@@ -307,7 +317,7 @@ function flattenPathAndMethod(paths: oas.PathsObject) {
 function generateHandler(schema: oas.OpenAPIObject, opts: Options) {
   const servers = (safe(schema).servers.$ || []).map(server => server.url);
   return ts.createVariableStatement(
-    undefined,
+    [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
     ts.createVariableDeclarationList(
       [
         ts.createVariableDeclaration(

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -82,6 +82,9 @@ components:
       properties:
         message:
           type: string
+        messageIndex:
+          type: number
       required:
         - message
+        - messageIndex
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,10 +289,10 @@
     "@types/form-data" "^2.2.1"
     form-data "^2.3.2"
 
-"@smartlyio/oats-koa-adapter@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-1.0.1.tgz#e6f63dea079f308441193443dd65b544806430fa"
-  integrity sha512-pXLJlqWM9AGiJUJDwn2726tM1E6bTROexIkiwRkmGovwACYk/SL1Ahrq/iS677AAQRQ5WDc6yXO9j3vva34Hmw==
+"@smartlyio/oats-koa-adapter@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-1.0.4.tgz#e554cf071af1b6aa9de999fb308a34dc1813a89c"
+  integrity sha512-+nknruvNVjeNIpgENDXEMcZ/N5KWLb+XEoIvet8rIc2oby6UcCrqtaGyR7EfaQOcXXGeMXS1PLggVp0otabfMg==
 
 "@smartlyio/oats-runtime@^1.0.0":
   version "1.0.0"
@@ -302,10 +302,10 @@
     "@smartlyio/safe-navigation" "^4.0.1"
     lodash "^4.17.4"
 
-"@smartlyio/oats-runtime@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-1.0.3.tgz#88499b3a0f38c810608c7c8f93c8657758db3801"
-  integrity sha512-qbIUQ4fzis0xLI1/D33dl1zsiOxRwNPNrnIu6anYOxceAoYzJcPVEStNlB6svg5gbayc7acgL6v16vPxs5nzqA==
+"@smartlyio/oats-runtime@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-1.0.5.tgz#114c907ee8cf4fe9bd5f6b088d021557a8a977c2"
+  integrity sha512-WCHNHAKo0cQN2HDy8MsPYCRsMF6P/xr2PBFK5YdUD2UkvVr9MdHv7RAjDQWFepAhtknB3E3ssbMAJzJpTdC2ig==
   dependencies:
     "@smartlyio/safe-navigation" "^4.0.1"
     lodash "^4.17.4"


### PR DESCRIPTION
Adds support for being able to provide request context to endpoint
handlers. Introduces new type `EndpointWithContext<RequestContext>`,
and changes Koa adapter to allow extracting data from koa context as
request context for the OpenAPI endpoints.