### PR TITLE
Include reflectable types

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,6 @@ jobs:
       - name: run tests
         run: |
           yarn install
-          yarn run build
+          yarn run build-all
         env:
           CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,6 @@ jobs:
         run: npm install -g yarn
       - name: run tests
         run: |
-          yarn install
           yarn run build-all
         env:
           CI: true

--- a/build-all.sh
+++ b/build-all.sh
@@ -10,14 +10,14 @@ yarn
 yarn link @smartlyio/oats-runtime
 yarn build
 yarn link
-cd ..
+cd ../..
 
 cd adapters/axios
 yarn
 yarn link @smartlyio/oats-runtime
 yarn build
 yarn link
-cd ..
+cd ../..
 
 yarn
 yarn link @smartlyio/oats-runtime

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,23 +1,23 @@
 set -e
 
-pushd runtime
+cd runtime
 yarn & yarn build
 yarn link
-popd
+cd ..
 
-pushd adapters/koa
+cd adapters/koa
 yarn
 yarn link @smartlyio/oats-runtime
 yarn build
 yarn link
-popd
+cd ..
 
-pushd adapters/axios
+cd adapters/axios
 yarn
 yarn link @smartlyio/oats-runtime
 yarn build
 yarn link
-popd
+cd ..
 
 yarn
 yarn link @smartlyio/oats-runtime

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,26 +1,35 @@
 set -e
+rm -rf node_modules
 
 cd runtime
-yarn & yarn build
+echo "building $PWD"
+rm -rf node_modules
+yarn
+yarn build
 yarn link
 cd ..
 
 cd adapters/koa
-yarn
+echo "building $PWD"
+rm -rf node_modules
 yarn link @smartlyio/oats-runtime
+yarn
 yarn build
 yarn link
 cd ../..
 
 cd adapters/axios
-yarn
+echo "building $PWD"
+rm -rf node_modules
 yarn link @smartlyio/oats-runtime
+yarn
 yarn build
 yarn link
 cd ../..
 
-yarn
+echo "building $PWD"
 yarn link @smartlyio/oats-runtime
 yarn link @smartlyio/oats-koa-adapter
 yarn link @smartlyio/oats-axios-adapter
+yarn
 yarn build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "build-all": "./build-all.sh",
     "test": "yarn jest test/",
     "render": "yarn ts-node examples/driver.ts && yarn ts-node render.ts",
     "build": "rm -rf ./dist/* && rm -f ./tmp/*.ts && yarn render && yarn test && yarn lint && yarn tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "^1.0.1",
     "@smartlyio/oats-koa-adapter": "^1.0.4",
-    "@smartlyio/oats-runtime": "^1.0.5",
+    "@smartlyio/oats-runtime": "^1.0.7",
     "@types/jest": "^25.0.0",
     "@types/koa": "^2.0.50",
     "@types/koa-mount": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "rm -rf ./dist/* && rm -f ./tmp/*.ts && yarn render && yarn test && yarn lint && yarn tsc",
     "lint": "tslint -c tslint.json --project package.json",
     "fix": "tslint --fix -c tslint.json --project package.json",
-    "prepublish": "yarn build"
+    "prepack": "yarn build-all"
   },
   "repository": {
     "type": "git",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "^25.0.0",
     "@types/lodash": "^4.14.140",
     "@types/node": "^11.11.3",
+    "jsverify": "^0.8.4",
     "typescript": "^3.6.3"
   },
   "jest": {

--- a/runtime/src/reflection-type.ts
+++ b/runtime/src/reflection-type.ts
@@ -2,6 +2,7 @@ import { Maker } from './make';
 
 export type Type =
   | UnknownType
+  | VoidType
   | IntegerType
   | NumberType
   | NullType
@@ -20,6 +21,10 @@ export interface NamedTypeDefinition<A> {
 
 export interface UnknownType {
   readonly type: 'unknown';
+}
+
+export interface VoidType {
+  readonly type: 'void';
 }
 
 export interface NullType {
@@ -43,10 +48,12 @@ export interface StringType {
 
 export interface NumberType {
   readonly type: 'number';
+  readonly enum: number[];
 }
 
 export interface IntegerType {
   readonly type: 'integer';
+  readonly enum: number[];
 }
 
 export interface ArrayType {

--- a/runtime/src/reflection-type.ts
+++ b/runtime/src/reflection-type.ts
@@ -43,6 +43,7 @@ export interface IntersectionType {
 
 export interface StringType {
   readonly type: 'string';
+  readonly format?: string;
   readonly enum?: string[];
 }
 

--- a/runtime/src/reflection-type.ts
+++ b/runtime/src/reflection-type.ts
@@ -1,0 +1,66 @@
+import { Maker } from './make';
+
+export type Type =
+  | UnknownType
+  | IntegerType
+  | NumberType
+  | NullType
+  | UnionType
+  | IntersectionType
+  | StringType
+  | ArrayType
+  | ObjectType
+  | NamedType;
+
+export interface NamedTypeDefinition<A> {
+  readonly name: string;
+  readonly definition: Type;
+  readonly maker: Maker<any, A>;
+}
+
+export interface UnknownType {
+  readonly type: 'unknown';
+}
+
+export interface NullType {
+  readonly type: 'null';
+}
+
+export interface UnionType {
+  readonly type: 'union';
+  readonly options: Type[];
+}
+
+export interface IntersectionType {
+  readonly type: 'intersection';
+  readonly options: Type[];
+}
+
+export interface StringType {
+  readonly type: 'string';
+  readonly enum?: string[];
+}
+
+export interface NumberType {
+  readonly type: 'number';
+}
+
+export interface IntegerType {
+  readonly type: 'integer';
+}
+
+export interface ArrayType {
+  readonly type: 'array';
+  readonly items: Type;
+}
+
+export interface NamedType {
+  readonly type: 'named';
+  readonly reference: NamedTypeDefinition<unknown>;
+}
+
+export interface ObjectType {
+  readonly type: 'object';
+  readonly additionalProperties: boolean | Type;
+  readonly properties: { [name: string]: { required: boolean; value: Type } };
+}

--- a/runtime/src/runtime.ts
+++ b/runtime/src/runtime.ts
@@ -2,8 +2,9 @@ import * as server from './server';
 import * as client from './client';
 import * as make from './make';
 import * as valueClass from './value-class';
+import * as reflection from './reflection-type';
 
-export { make, server, client, valueClass };
+export { make, server, client, valueClass, reflection };
 
 export function json<Status extends number, Value>(
   status: Status,

--- a/runtime/src/value-class.ts
+++ b/runtime/src/value-class.ts
@@ -1,3 +1,5 @@
+import { NamedTypeDefinition } from './reflection-type';
+
 export type Branded<A, BrandTag> = A & Brand<BrandTag>;
 
 export class Brand<B> {
@@ -19,6 +21,7 @@ function asPlainObject(value: any): any {
 }
 
 export class ValueClass<Shape, BrandTag> extends Brand<BrandTag> {
+  public static reflection: NamedTypeDefinition<ValueClass<any, any>>;
   private Shape!: Shape;
 }
 

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -131,6 +131,21 @@ jest-get-type@^25.1.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
   integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
 
+jsverify@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/jsverify/-/jsverify-0.8.4.tgz#b914ccc024103d946b503f18ee780ec43febeece"
+  integrity sha512-nUG73Sfi8L4eOkc7pv9sflgAm43v+z6XMuePGVdRoBUxBLJiVcMcf3Xgc4h19eHHF3JwsaagOkUu825UnPBLJw==
+  dependencies:
+    lazy-seq "^1.0.0"
+    rc4 "~0.1.5"
+    trampa "^1.0.0"
+    typify-parser "^1.1.0"
+
+lazy-seq@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazy-seq/-/lazy-seq-1.0.0.tgz#880cb8aab256026382e02f53ec089682a74c5b6a"
+  integrity sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=
+
 lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -146,6 +161,11 @@ pretty-format@^25.1.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+rc4@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/rc4/-/rc4-0.1.5.tgz#08c6e04a0168f6eb621c22ab6cb1151bd9f4a64d"
+  integrity sha1-CMbgSgFo9utiHCKrbLEVG9n0pk0=
+
 react-is@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -158,7 +178,17 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+trampa@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trampa/-/trampa-1.0.1.tgz#b866bc192331f64b4f57a8acf4ab71d0e900b692"
+  integrity sha512-93WeyHNuRggPEsfCe+yHxCgM2s6H3Q8Wmlt6b6ObJL8qc7eZlRaFjQxwTrB+zbvGtlDRnAkMoYYo3+2uH/fEwA==
+
 typescript@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
+typify-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/typify-parser/-/typify-parser-1.1.0.tgz#ac73bfa5f25343468e2d0f3346c6117bc03d3c99"
+  integrity sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -515,6 +515,19 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
         )
       ])
     ),
+    ts.createProperty(
+      undefined,
+      [
+        ts.createModifier(ts.SyntaxKind.PublicKeyword),
+        ts.createModifier(ts.SyntaxKind.StaticKeyword)
+      ],
+      ts.createIdentifier('reflection'),
+      undefined,
+      ts.createTypeReferenceNode(fromLib('reflection', 'NamedTypeDefinition'), [
+        ts.createTypeReferenceNode(ts.createIdentifier(oautil.typenamify(key)), [])
+      ]),
+      undefined
+    ),
     ts.createMethod(
       undefined,
       [ts.createModifier(ts.SyntaxKind.StaticKeyword)],

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -749,6 +749,12 @@ function generateReflectionType(
     return generateReflectionType({ oneOf: [{ ...schema, nullable: false }, { type: 'null' }] });
   }
 
+  if (schema.type === 'void') {
+    return ts.createObjectLiteral(
+      [ts.createPropertyAssignment('type', ts.createStringLiteral('void'))],
+      true
+    );
+  }
   if (schema.type === 'null') {
     return ts.createObjectLiteral(
       [ts.createPropertyAssignment('type', ts.createStringLiteral('null'))],
@@ -772,16 +778,32 @@ function generateReflectionType(
     );
   }
   if (schema.type === 'number') {
-    assert(!schema.enum);
+    const enumValues = schema.enum
+      ? [
+          ts.createPropertyAssignment(
+            'enum',
+            ts.createArrayLiteral(schema.enum.map(i => ts.createNumericLiteral('' + i)))
+          )
+        ]
+      : [];
+
     return ts.createObjectLiteral(
-      [ts.createPropertyAssignment('type', ts.createStringLiteral('number'))],
+      [ts.createPropertyAssignment('type', ts.createStringLiteral('number')), ...enumValues],
       true
     );
   }
   if (schema.type === 'integer') {
-    assert(!schema.enum);
+    const enumValues = schema.enum
+      ? [
+          ts.createPropertyAssignment(
+            'enum',
+            ts.createArrayLiteral(schema.enum.map(i => ts.createNumericLiteral('' + i)))
+          )
+        ]
+      : [];
+
     return ts.createObjectLiteral(
-      [ts.createPropertyAssignment('type', ts.createStringLiteral('integer'))],
+      [ts.createPropertyAssignment('type', ts.createStringLiteral('integer')), ...enumValues],
       true
     );
   }
@@ -1024,7 +1046,8 @@ function generateTopLevelType(
         ts.createTypeReferenceNode(type, undefined)
       ),
       generateTypeShape(key, schema),
-      generateTopLevelMaker(key, schema)
+      generateTopLevelMaker(key, schema),
+      generateNamedTypeDefinitionAssignment(key, schema)
     ];
   }
   if (schema.type === 'object') {
@@ -1061,7 +1084,8 @@ function generateTopLevelType(
       generateType(schema)
     ),
     generateTypeShape(key, schema),
-    generateTopLevelMaker(key, schema)
+    generateTopLevelMaker(key, schema),
+    generateNamedTypeDefinitionAssignment(key, schema)
   ];
 }
 

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -776,7 +776,11 @@ function generateReflectionType(
       : [];
 
     return ts.createObjectLiteral(
-      [ts.createPropertyAssignment('type', ts.createStringLiteral('string')), ...enumValues, ...format],
+      [
+        ts.createPropertyAssignment('type', ts.createStringLiteral('string')),
+        ...enumValues,
+        ...format
+      ],
       true
     );
   }

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -771,9 +771,12 @@ function generateReflectionType(
           )
         ]
       : [];
+    const format = schema.format
+      ? [ts.createPropertyAssignment('format', ts.createStringLiteral(schema.format))]
+      : [];
 
     return ts.createObjectLiteral(
-      [ts.createPropertyAssignment('type', ts.createStringLiteral('string')), ...enumValues],
+      [ts.createPropertyAssignment('type', ts.createStringLiteral('string')), ...enumValues, ...format],
       true
     );
   }

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -515,6 +515,17 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
         )
       ])
     ),
+    ts.createProperty(
+      undefined,
+      [
+        ts.createModifier(ts.SyntaxKind.PublicKeyword),
+        ts.createModifier(ts.SyntaxKind.StaticKeyword)
+      ],
+      ts.createIdentifier('reflection'),
+      undefined,
+      undefined,
+      ts.createIdentifier('type' + oautil.typenamify(key))
+    ),
     ts.createMethod(
       undefined,
       [ts.createModifier(ts.SyntaxKind.StaticKeyword)],
@@ -992,10 +1003,10 @@ function generateTopLevelType(
     return [
       generateObjectShape(key, schema),
       generateBrand(key),
+      generateNamedTypeDefinition(key, schema),
       generateValueClass(key, schema),
       generateTopLevelClassBuilder(key, schema),
-      generateTopLevelClassMaker(key, schema, oautil.typenamify(key)),
-      generateNamedTypeDefinition(key, schema)
+      generateTopLevelClassMaker(key, schema, oautil.typenamify(key))
     ];
   }
   if (isScalar(schema)) {

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -515,17 +515,6 @@ function generateValueClass(key: string, schema: oas.SchemaObject) {
         )
       ])
     ),
-    ts.createProperty(
-      undefined,
-      [
-        ts.createModifier(ts.SyntaxKind.PublicKeyword),
-        ts.createModifier(ts.SyntaxKind.StaticKeyword)
-      ],
-      ts.createIdentifier('reflection'),
-      undefined,
-      undefined,
-      ts.createIdentifier('type' + oautil.typenamify(key))
-    ),
     ts.createMethod(
       undefined,
       [ts.createModifier(ts.SyntaxKind.StaticKeyword)],
@@ -978,6 +967,19 @@ function generateScalarBrand(key: string) {
   );
 }
 
+function generateValueClassReflectionAssignment(key: string) {
+  return ts.createExpressionStatement(
+    ts.createBinary(
+      ts.createPropertyAccess(
+        ts.createIdentifier(oautil.typenamify(key)),
+        ts.createIdentifier('reflection')
+      ),
+      ts.createToken(ts.SyntaxKind.EqualsToken),
+      ts.createNumericLiteral('type' + oautil.typenamify(key))
+    )
+  );
+}
+
 function generateTopLevelType(
   key: string,
   schema: oas.SchemaObject | oas.ReferenceObject
@@ -1003,10 +1005,11 @@ function generateTopLevelType(
     return [
       generateObjectShape(key, schema),
       generateBrand(key),
-      generateNamedTypeDefinition(key, schema),
       generateValueClass(key, schema),
       generateTopLevelClassBuilder(key, schema),
-      generateTopLevelClassMaker(key, schema, oautil.typenamify(key))
+      generateTopLevelClassMaker(key, schema, oautil.typenamify(key)),
+      generateNamedTypeDefinition(key, schema),
+      generateValueClassReflectionAssignment(key)
     ];
   }
   if (isScalar(schema)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,10 +461,10 @@
     "@smartlyio/safe-navigation" "^4.0.1"
     lodash "^4.17.4"
 
-"@smartlyio/oats-runtime@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-1.0.5.tgz#114c907ee8cf4fe9bd5f6b088d021557a8a977c2"
-  integrity sha512-WCHNHAKo0cQN2HDy8MsPYCRsMF6P/xr2PBFK5YdUD2UkvVr9MdHv7RAjDQWFepAhtknB3E3ssbMAJzJpTdC2ig==
+"@smartlyio/oats-runtime@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-1.0.7.tgz#52d8e54abd0d665a042d290522f30c7435f3f357"
+  integrity sha512-iFWWC7t3JpluVgjipwB4kdYa3yGipH9gig72NVczjk6FjpjwXXTEKI1qg1/n0J4yWsFOg6i8Py7LGqAofPkUaQ==
   dependencies:
     "@smartlyio/safe-navigation" "^4.0.1"
     lodash "^4.17.4"


### PR DESCRIPTION
add runtime type info for values so that we can type strings and generate values

todo

 - [x] include format to the string type

solves https://github.com/smartlyio/oats/issues/40