### PR TITLE
Don't resolve installed modules

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -23,6 +23,7 @@ function modulePath(importer: string, module: string | undefined) {
 export interface ImportDefinition {
   importFile: string;
   importAs: string;
+  isInstalledModule?: boolean;
 }
 
 export interface Driver {
@@ -58,7 +59,7 @@ export function generate(driver: Driver) {
       '\n' +
       types.run({
         externalOpenApiImports: (driver.externalOpenApiImports || []).map(i => ({
-          importFile: resolveModule(driver.generatedValueClassFile, i.importFile),
+          importFile: i.isInstalledModule ? i.importFile : resolveModule(driver.generatedValueClassFile, i.importFile),
           importAs: i.importAs
         })),
         externalOpenApiSpecs: driver.externalOpenApiSpecs || (() => undefined),

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -59,7 +59,9 @@ export function generate(driver: Driver) {
       '\n' +
       types.run({
         externalOpenApiImports: (driver.externalOpenApiImports || []).map(i => ({
-          importFile: i.isInstalledModule ? i.importFile : resolveModule(driver.generatedValueClassFile, i.importFile),
+          importFile: i.isInstalledModule
+            ? i.importFile
+            : resolveModule(driver.generatedValueClassFile, i.importFile),
           importAs: i.importAs
         })),
         externalOpenApiSpecs: driver.externalOpenApiSpecs || (() => undefined),

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -43,7 +43,7 @@ function emitAllStatusCodes() {
 
 function resolveModule(fromModule: string, toModule: string): string {
   if (!toModule.startsWith('.')) {
-      return toModule;
+    return toModule;
   }
 
   const p = path.relative(path.dirname(fromModule), toModule);

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -23,7 +23,6 @@ function modulePath(importer: string, module: string | undefined) {
 export interface ImportDefinition {
   importFile: string;
   importAs: string;
-  isInstalledModule?: boolean;
 }
 
 export interface Driver {
@@ -43,6 +42,10 @@ function emitAllStatusCodes() {
 }
 
 function resolveModule(fromModule: string, toModule: string): string {
+  if (!toModule.startsWith('.')) {
+      return toModule;
+  }
+
   const p = path.relative(path.dirname(fromModule), toModule);
   if (p[0] === '.') {
     return p;
@@ -59,9 +62,7 @@ export function generate(driver: Driver) {
       '\n' +
       types.run({
         externalOpenApiImports: (driver.externalOpenApiImports || []).map(i => ({
-          importFile: i.isInstalledModule
-            ? i.importFile
-            : resolveModule(driver.generatedValueClassFile, i.importFile),
+          importFile: resolveModule(driver.generatedValueClassFile, i.importFile),
           importAs: i.importAs
         })),
         externalOpenApiSpecs: driver.externalOpenApiSpecs || (() => undefined),


### PR DESCRIPTION
**Motivation**

I have `Module1` where I want to import openapi from `Module2`. Currently I can do it by relative path to `node_modules` and it works pretty fine. But after that I want to import openapi from `Module1` to `Module3`. And `Module2` installs as dependency of `Module2` in subfolder `node_modules`

```
/node_modules
    /Module1
        /node_modules
             /Module2
```

and when I try to build my `Module3` relative path starts to point on a wrong place in `node_modules` structure.
**My suggestion here**: allow using of installed modules names as root instead of relative path by setting `isInstalledModule` option. In this case module will not be resolved with relative path and we build types with imports from installed modules in `node_modules`.
Probably having additional flag is a little bit dirty approach but we can't rely only on node_modules in path

**Real example**

We have `v8` types which I want to use in `action library` (reuse Ad structure). And `action library` is used by `hermes` to build types.