### PR TITLE
Nullable bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ javascript class `NamedComponent`
  - For scalar types oats adds typescript branding to differentiate between various kinds of 
  named scalar types
  
+ For `type: object` schemas that are `nullable: true` the type is split to a `type NamedComponent = null | NonNullableNamedComponent` 
+ where `NonNullableNamedComponent` is the actual class as class instances really cannot be `null`.
+ 
  See [runtime](https://github.com/smartlyio/oats-runtime) for details on working with the types.
  
  The rest of the generated type definitions consist of the apis for clients and servers for actually 

--- a/README.template.md
+++ b/README.template.md
@@ -28,6 +28,9 @@ javascript class `NamedComponent`
  - For scalar types oats adds typescript branding to differentiate between various kinds of 
  named scalar types
  
+ For `type: object` schemas that are `nullable: true` the type is split to a `type NamedComponent = null | NonNullableNamedComponent` 
+ where `NonNullableNamedComponent` is the actual class as class instances really cannot be `null`.
+ 
  See [runtime](https://github.com/smartlyio/oats-runtime) for details on working with the types.
  
  The rest of the generated type definitions consist of the apis for clients and servers for actually 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "render": "yarn ts-node examples/driver.ts && yarn ts-node render.ts",
     "clean": "rm -rf ./dist/*",
-    "build": "yarn clean && yarn render && yarn lint && yarn tsc",
+    "build": "yarn clean && yarn render && yarn jest && yarn lint && yarn tsc",
     "prepublish": "yarn build",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix"

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -1112,16 +1112,16 @@ function generateTopLevelClass(key: string, schema: oas.SchemaObject): readonly 
   if (schema.nullable) {
     const classKey = oautil.nonNullableClass(key);
     const proxy = generateTopLevelType(key, {
-      oneOf: [{
-        type: 'null'
-      }, {
-        $ref: '#/components/schemas/' + classKey
-      }]
+      oneOf: [
+        {
+          type: 'null'
+        },
+        {
+          $ref: '#/components/schemas/' + classKey
+        }
+      ]
     });
-    return [
-      ...generateTopLevelClass(classKey, { ...schema, nullable: false }),
-      ...proxy
-    ]
+    return [...generateTopLevelClass(classKey, { ...schema, nullable: false }), ...proxy];
   }
   return [
     generateObjectShape(key, schema),

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,6 +12,11 @@ export function isReferenceObject(schema: any): schema is oas.ReferenceObject {
 export function capitalize(str: string) {
   return str[0].toUpperCase() + str.slice(1);
 }
+
+export function nonNullableClass(name: string) {
+  return 'nonNullable' + typenamify(name);
+}
+
 export function typenamify(name: string) {
   if (name.match(/^[^a-zA-Z]/)) {
     name = 'Type' + name;

--- a/test/codegen.spec.ts
+++ b/test/codegen.spec.ts
@@ -1,0 +1,9 @@
+import * as types from '../tmp/common.types.generated';
+describe('codegen', () => {
+  it('splits nullable types', () => {
+    expect(types.typeNullable.maker(null).success()).toBeNull();
+    expect(types.typeNullable.maker({ field: 'abc' }).success()).toBeInstanceOf(
+      types.NonNullableNullable
+    );
+  });
+});

--- a/test/common.yaml
+++ b/test/common.yaml
@@ -7,6 +7,12 @@ servers:
 paths: {}
 components:
   schemas:
+    Nullable:
+      type: object
+      nullable: true
+      properties:
+        field:
+          type: string
     ItemId:
       type: string
     Item:
@@ -23,4 +29,6 @@ components:
           pattern: .*
         flag:
           type: boolean
+        nullableField:
+          $ref: '#/components/schemas/Nullable'
 


### PR DESCRIPTION
split nullable classes to 'null | NonNullableSomeClass'
    
the class cannot be nullable as it needs to be a proper js class so we need to do some hackery. This fixes https://github.com/smartlyio/oats/issues/58 about constructing empty objects from nullable

The downside is that we end up with ugly NonNullableSomeClass for the actual class which also might break some existing code relying on `instanceof SomeClass`