### PR TITLE
Support custom maker function using `x-oats-maker`

### DIFF
--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -1042,21 +1042,25 @@ function generateTopLevelMaker(
       [
         ts.createVariableDeclaration(
           name + oautil.typenamify(key),
-          ts.createTypeReferenceNode(fromLib('make', 'Maker'), [
-            ts.createTypeReferenceNode(shape, []),
-            ts.createTypeReferenceNode(resultType, [])
-          ]),
-          makeCall(makerFun, [
-            ts.createFunctionExpression(
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              [],
-              undefined,
-              ts.createBlock([ts.createReturn(generateMakerExpression(schema))])
-            )
-          ])
+          schema['x-oats-maker']
+            ? undefined
+            : ts.createTypeReferenceNode(fromLib('make', 'Maker'), [
+                ts.createTypeReferenceNode(shape, []),
+                ts.createTypeReferenceNode(resultType, [])
+              ]),
+          schema['x-oats-maker']
+            ? ts.createIdentifier(schema['x-oats-maker'])
+            : makeCall(makerFun, [
+                ts.createFunctionExpression(
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  [],
+                  undefined,
+                  ts.createBlock([ts.createReturn(generateMakerExpression(schema))])
+                )
+              ])
         )
       ],
       ts.NodeFlags.Const


### PR DESCRIPTION
Allows one to use `x-oats-maker` to define custom maker function for
the type. This allows cleaning up, and sanitizing things when building
the data types.

E.g.

```
export const buildStringFromMongoId: Maker<any, ShapeOfMongoObjectId> = (value, opts) =>
  oar.make.makeString()(value.toString(), opts);
```

And in schema:

```
MongoObjectId:
  type: string
  x-oats-maker: 'mongoTools.buildStringFromMongoId'
```

You can use `externalOpenApiImports` to import functions into scope.