### PR TITLE
Fix bool enums

### DIFF
--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -963,9 +963,9 @@ export function run(options: Options) {
               'enum',
               ts.createArrayLiteral(
                 schema.enum.map(i =>
-                  i === 'true'
+                  i === true
                     ? ts.createTrue()
-                    : i === 'false'
+                    : i === false
                     ? ts.createFalse()
                     : assert.fail('unknown enum ' + i)
                 )

--- a/test/codegen.spec.ts
+++ b/test/codegen.spec.ts
@@ -6,4 +6,9 @@ describe('codegen', () => {
       types.NonNullableNullable
     );
   });
+
+  it('works correctly with boolean enums', () => {
+    expect(types.typeGuard.maker(true).success()).toBe(true);
+    expect(types.typeGuard.maker(false as any).success).toThrowError();
+  })
 });

--- a/test/codegen.spec.ts
+++ b/test/codegen.spec.ts
@@ -10,5 +10,5 @@ describe('codegen', () => {
   it('works correctly with boolean enums', () => {
     expect(types.typeGuard.maker(true).success()).toBe(true);
     expect(types.typeGuard.maker(false as any).success).toThrowError();
-  })
+  });
 });

--- a/test/common.yaml
+++ b/test/common.yaml
@@ -29,10 +29,9 @@ components:
           pattern: .*
         flag:
           type: boolean
-        guard:
-          type: boolean
-          enum:
-            - true
         nullableField:
           $ref: '#/components/schemas/Nullable'
-
+    Guard:
+      type: boolean
+      enum:
+        - true

--- a/test/common.yaml
+++ b/test/common.yaml
@@ -29,6 +29,10 @@ components:
           pattern: .*
         flag:
           type: boolean
+        guard:
+          type: boolean
+          enum:
+            - true
         nullableField:
           $ref: '#/components/schemas/Nullable'
 


### PR DESCRIPTION
I need type in smartly-actions with flag `enabled: boolean`. By this flag I want to choose what type to use: no additional fields for `false` and to required fields for `true`. Current oats implementation threats boolean enum as string. This PR contains fix