### PR TITLE
Fix require body when it is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -23,7 +23,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^2.7.1",
+    "@smartlyio/oats-runtime": "^2.7.3",
     "typescript": "^3.8.3"
   },
   "dependencies": {
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "2.2.3",
     "@smartlyio/oats-koa-adapter": "2.0.1",
-    "@smartlyio/oats-runtime": "2.7.1",
+    "@smartlyio/oats-runtime": "2.7.3",
     "@types/jest": "26.0.15",
     "@types/js-yaml": "3.12.5",
     "@types/koa": "2.11.6",

--- a/test/optional-queries/api.yml
+++ b/test/optional-queries/api.yml
@@ -5,6 +5,22 @@ info:
 servers:
   - url: http://localhost:12000
 paths:
+  /hasbody:
+    post:
+      description: mandatory body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
   /item/{id}:
     post:
       description: no query parameters

--- a/test/optional-queries/optional-queries.spec.ts
+++ b/test/optional-queries/optional-queries.spec.ts
@@ -73,6 +73,17 @@ describe('optional queries', () => {
     });
   });
 
+  describe('with mandatory body', () => {
+    it('requires body to be given', async () => {
+      // @ts-expect-error unknown query parameter
+      await expect(apiClient.hasbody.post()).rejects.toThrow();
+    });
+
+    it('allows body', async () => {
+      await expect(apiClient.hasbody.post({ body: runtime.client.json('abc') })).rejects.toThrow();
+    });
+  });
+
   describe('with no query parameters', () => {
     it('allows calling without any query parameters whene there are path params', async () => {
       const item = await apiClient.item('abc').post();

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,10 +664,10 @@
   resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-2.0.1.tgz#aac15fb429de4c945d9bdc5c466afc437b0fe94f"
   integrity sha512-Ub5g/EA3zBP3++lWD3dJRU+7Gn2JXK0+GoOTFJAsKD0ebW4SPkquTrXXGVOuD7zGu9BGaCEbQxGb2daaGp3XeA==
 
-"@smartlyio/oats-runtime@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.7.1.tgz#a846baf1fb7d6b873c8ff4fe00f11091eee84745"
-  integrity sha512-Uid7/cP7bdVD/BF9OF7dE2Jlu+3HCksD/u1WAXdgZLSzWEvdzK7IcU9tK/GtzwxBUHflQ1t9gxTtaft3Q9mLrg==
+"@smartlyio/oats-runtime@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.7.3.tgz#727bdf75c4d561ddafeed2ee5b22d14a11447b17"
+  integrity sha512-bXJHRi09RkMABqr3amDijyyi/Ef5r4cKFMGlrJcGbmhkk6jX5YQeYzvqE4UpJvlFNR+JU79PCul5bWTsW7GWMA==
   dependencies:
     "@smartlyio/safe-navigation" "^5.0.1"
     lodash "^4.17.20"


### PR DESCRIPTION
use oats-runtime 2.7.3 to ensure that the body in a client request is required (when it actually should be there)