### PR TITLE
Add reponse headers property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 *.iml
 .DS_Store
 *.tgz
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^2.7.3",
+    "@smartlyio/oats-runtime": "^2.8.0",
     "typescript": "^3.8.3"
   },
   "dependencies": {
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "2.2.4",
     "@smartlyio/oats-koa-adapter": "2.0.2",
-    "@smartlyio/oats-runtime": "2.7.3",
+    "@smartlyio/oats-runtime": "2.8.0",
     "@types/jest": "26.0.16",
     "@types/js-yaml": "3.12.5",
     "@types/koa": "2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -42,7 +42,7 @@
     "client"
   ],
   "devDependencies": {
-    "@smartlyio/oats-axios-adapter": "2.2.4",
+    "@smartlyio/oats-axios-adapter": "2.3.0",
     "@smartlyio/oats-koa-adapter": "2.0.2",
     "@smartlyio/oats-runtime": "2.8.0",
     "@types/jest": "26.0.16",

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -359,7 +359,7 @@ export function run(options: Options) {
         required.push(headerName);
         return { ...memo, [headerName]: headerObject };
       } else if (headerObject.schema) {
-        required.push(headerName);
+        if (headerObject.required) required.push(headerName);
         return { ...memo, [headerName]: headerObject.schema };
       }
       return memo;

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -439,7 +439,7 @@ export function run(options: Options) {
                     }
                   }
                 ),
-            headers: { type: 'object', nullable: true }
+            headers: { type: 'object' }
           },
           required: ['status', 'value', 'headers'],
           additionalProperties: false

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -438,14 +438,14 @@ export function run(options: Options) {
                       }
                     }
                   }
-                )
+                ),
+            headers: { type: 'object', nullable: true }
           },
-          required: ['status', 'value'],
+          required: ['status', 'value', 'headers'],
           additionalProperties: false
         };
         if (!oautil.isReferenceObject(response) && response.headers) {
           schema.properties!.headers = generateHeadersSchemaType(response.headers);
-          schema.required!.push('headers');
         }
         responseSchemas.push(schema);
       }

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -368,7 +368,9 @@ export function run(options: Options) {
       type: 'object',
       properties,
       required,
-      additionalProperties: true
+      additionalProperties: {
+        type: 'string'
+      }
     };
   }
 

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -20,6 +20,10 @@ paths:
       responses:
         '201':
           description: created
+          headers:
+            location:
+              schema:
+                type: string
           content:
             application/json:
               schema:

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,10 +664,10 @@
   resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-2.0.2.tgz#49488e154cd336d3ce89fef879c1107a0505b38f"
   integrity sha512-z/DFu9fk8PgOwHT33+lZTR7wQnHMm14vgLnOR/6VDfxM0+bMONBsr0ROR6vVbt6uBXTFx3GvIANIyQM1HklN1g==
 
-"@smartlyio/oats-runtime@2.7.3":
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.7.3.tgz#727bdf75c4d561ddafeed2ee5b22d14a11447b17"
-  integrity sha512-bXJHRi09RkMABqr3amDijyyi/Ef5r4cKFMGlrJcGbmhkk6jX5YQeYzvqE4UpJvlFNR+JU79PCul5bWTsW7GWMA==
+"@smartlyio/oats-runtime@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.8.0.tgz#aec2a5dd402d5e7d28f5bec4eb9495a943bc4fa1"
+  integrity sha512-Av/l2zJrsHAqQZHUlxZTxTaRVzJ55QJxp2Czg8Mq/9khnxyslUsp3Yta4ePMLTOIT5OMmqnLk/3og+PRf0JXnA==
   dependencies:
     "@smartlyio/safe-navigation" "^5.0.1"
     lodash "^4.17.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@smartlyio/oats-axios-adapter@2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-axios-adapter/-/oats-axios-adapter-2.2.4.tgz#221efa8ef375ce535095594d2a4750c1e9bccae0"
-  integrity sha512-Wod6mQI3YwQHsNA4NjnLfHYqrWpcnZhhxCinjPjRxXUo+UxvQON7uuTi2uKB8SGS9EYrWPxz1zLLNGsxFkWjwg==
+"@smartlyio/oats-axios-adapter@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-axios-adapter/-/oats-axios-adapter-2.3.0.tgz#fa1d26ea4d96c30e2bfb788254d9469c22bb118d"
+  integrity sha512-R5vZ7lHjywGDB1pNdeqTo32dGeu0UjqnWkiEBDF2BLqkfwr9/6hfjnC2JruEbBj/rHzMFeqEE5Y24ovWvNVQTw==
   dependencies:
     form-data "^3.0.0"
 


### PR DESCRIPTION
It would look something like this and would allow us to access the header properties that are declared in the openapi spec
```ts
{
    readonly status: 201;
    readonly value: {
        readonly contentType: "application/json";
        readonly value: common.ShapeOfItem;
    };
    readonly headers: {
        readonly location: string;
    };
}
```

https://github.com/smartlyio/oats-runtime/pull/106
https://github.com/smartlyio/oats-axios-adapter/pull/42