### PR TITLE
Add support for discriminator in oneOf

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "2.3.0",
     "@smartlyio/oats-koa-adapter": "2.2.0",
-    "@smartlyio/oats-runtime": "2.11.2",
+    "@smartlyio/oats-runtime": "file:.yalc/@smartlyio/oats-runtime",
     "@types/jest": "26.0.20",
     "@types/js-yaml": "3.12.5",
     "@types/koa": "2.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -23,7 +23,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^2.11.2",
+    "@smartlyio/oats-runtime": "^2.12.0",
     "typescript": "^4.0.0"
   },
   "dependencies": {
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "2.3.0",
     "@smartlyio/oats-koa-adapter": "2.2.0",
-    "@smartlyio/oats-runtime": "file:.yalc/@smartlyio/oats-runtime",
+    "@smartlyio/oats-runtime": "^2.12.0",
     "@types/jest": "26.0.20",
     "@types/js-yaml": "3.12.5",
     "@types/koa": "2.11.7",

--- a/test/codegen.spec.ts
+++ b/test/codegen.spec.ts
@@ -1,14 +1,52 @@
-import * as types from '../tmp/client/common.types.generated';
+import * as common from '../tmp/client/common.types.generated';
+import * as types from '../tmp/client/types.generated';
+
 describe('codegen', () => {
   it('splits nullable types', () => {
-    expect(types.typeNullable.maker(null).success()).toBeNull();
-    expect(types.typeNullable.maker({ field: 'abc' }).success()).toBeInstanceOf(
-      types.NonNullableNullable
+    expect(common.typeNullable.maker(null).success()).toBeNull();
+    expect(common.typeNullable.maker({ field: 'abc' }).success()).toBeInstanceOf(
+      common.NonNullableNullable
     );
   });
 
   it('works correctly with boolean enums', () => {
-    expect(types.typeGuard.maker(true).success()).toBe(true);
-    expect(types.typeGuard.maker(false as any).success).toThrowError();
+    expect(common.typeGuard.maker(true).success()).toBe(true);
+    expect(common.typeGuard.maker(false as any).success).toThrowError();
+  });
+
+  it('oneOf with discriminator with implicit mappings works properly', () => {
+    expect(common.typeChoice.maker({ type: 'choice1', field: 'foo' }).success()).toEqual({
+      type: 'choice1',
+      field: 'foo'
+    });
+    expect(common.typeChoice.maker({ type: 'choice3', field3: 'foo' }).success()).toBeInstanceOf(
+      common.ChoiceItem3
+    );
+    expect(common.typeChoice.maker({ type: 'choice2', field: 'foo' } as any).errors).toEqual([
+      { error: 'unexpected property', path: ['field'] }
+    ]);
+    expect(
+      types.typeChoiceWithExternalRef.maker({ type: 'choice3', field3: 'foo' }).success()
+    ).toBeInstanceOf(common.ChoiceItem3);
+  });
+
+  it('oneOf with discriminator with explicit mappings works properly', () => {
+    expect(
+      types.typeChoiceWithExplicitMapping.maker({ type: 'choice4', field4: 'foo' }).success()
+    ).toEqual({
+      type: 'choice4',
+      field4: 'foo'
+    });
+    expect(
+      types.typeChoiceWithExplicitMapping.maker({ type: 'choice3', field3: 'foo' }).success()
+    ).toBeInstanceOf(common.ChoiceItem3);
+    expect(
+      types.typeChoiceWithExplicitMapping.maker({ type: 'choice2', field: 'foo' } as any).errors
+    ).toEqual([
+      {
+        error: 'unexpected value "choice2" in field "type" which is used as discriminator',
+        path: []
+      }
+    ]);
   });
 });

--- a/test/common.yaml
+++ b/test/common.yaml
@@ -31,6 +31,42 @@ components:
           type: boolean
         nullableField:
           $ref: '#/components/schemas/Nullable'
+    ChoiceItem3:
+      type: object
+      additionalProperties: false
+      required: 
+        - type
+      properties:
+        type:
+          type: string
+          enum: ['choice3']
+        field3: 
+          type: string
+    Choice:
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: 
+            - type
+          properties:
+            type:
+              type: string
+              enum: ['choice1']
+            field: 
+              type: string
+        - type: object
+          additionalProperties: false
+          required: 
+            - type
+          properties:
+            type:
+              type: string
+              enum: ['choice2']
+            field2: 
+              type: string
+        - $ref: "#/components/schemas/ChoiceItem3"
+      discriminator:
+        propertyName: type
     Guard:
       type: boolean
       enum:

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -101,3 +101,41 @@ components:
         - message
         - messageIndex
 
+    ChoiceWithExternalRef:
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum: ['choice1']
+            field:
+              type: string
+        - $ref: "common.yaml#/components/schemas/ChoiceItem3"
+      discriminator:
+        propertyName: type
+
+    ChoiceItem4:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: ['choice4']
+        field4:
+          type: string
+
+    ChoiceWithExplicitMapping:
+      oneOf:
+        - $ref: "common.yaml#/components/schemas/ChoiceItem3"
+        - $ref: "#/components/schemas/ChoiceItem4"
+      discriminator:
+        propertyName: type
+        mapping:
+          choice3: "common.yaml#/components/schemas/ChoiceItem3"
+          choice4: "#/components/schemas/ChoiceItem4"
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,10 +664,10 @@
   resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-2.2.0.tgz#9eea5de87c3a840aef89fa44d986b2405f4dd6f4"
   integrity sha512-ojny69UgR5JQx4N1+/rYR7EADLzQ55wLT9Jriac9k+GHp4Z4dNxMVJkXDvXkas1zoL5J+zOXoHL4noyB5ge+fg==
 
-"@smartlyio/oats-runtime@2.11.2":
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.11.2.tgz#314ca65ae94c27da28aeb3028bfaaba51f082ed4"
-  integrity sha512-GrDMOFKp3XlFzuUghbu9IrxfWQaEiSA7ENl4BIgaISPvq7bGed6cl6mG2hW3XFJe/GKSzC6NwR9Bg/GKKliXJg==
+"@smartlyio/oats-runtime@^2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.12.0.tgz#ccd07b5f997d695a9512934e96506a0b19d4498f"
+  integrity sha512-pSJaQgnwH1UKe2qCcKMJftdh3oSGskOQkyj+zp5S64UU/MlrNoHVkGjgwYDbtFMiDQ+Zn2rdcMhFkvCf7GzmNw==
   dependencies:
     "@smartlyio/safe-navigation" "^5.0.1"
     lodash "^4.17.20"


### PR DESCRIPTION
Generates separate makeOneOfWithDiscriminator if discriminator
configuration is specified for oneOf. This allows make to home into
correct maker immediately without trying all the options, which improves
performance a lot.

With Caesar actions the difference was:

```
Before

makeAction x 2,624 ops/sec ±1.85% (86 runs sampled)

After

makeAction x 342,554 ops/sec ±1.74% (85 runs sampled)
```

Requires https://github.com/smartlyio/oats-runtime/pull/127. Will need to
bump version numbers once that is in.