### PR TITLE
Export generate-types as well

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import * as driver from './src/driver';
 import * as util from './src/util';
+import * as types from './src/generate-types';
 
-export { driver, util };
+export { driver, util, types };

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import * as driver from './src/driver';
 import * as util from './src/util';
-import * as types from './src/generate-types';
+import { Resolve } from './src/generate-types';
 
-export { driver, util, types };
+export { driver, util, Resolve };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,


### PR DESCRIPTION
For `oats-generator` project we need `Resolve` type from `generate-types` which is not exported now, so we use type `driver.Driver['resolve']` which is kinda OK-ish, but it's type also contains `undefined` which is not true in our use-case there, so we do ugly `!` at the end of function call to tell TypeScript that it should be always with a `Resolve` type.

So may we can export `generate-types` and use Resolve type directly?