### PR TITLE
ShapeOf is no longer necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "license": "MIT",
   "description": "Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@smartlyio/oats-axios-adapter": "2.3.1",
     "@smartlyio/oats-koa-adapter": "2.2.0",
-    "@smartlyio/oats-runtime": "2.12.1",
+    "@smartlyio/oats-runtime": "2.13.0",
     "@types/jest": "26.0.22",
     "@types/js-yaml": "4.0.0",
     "@types/koa": "2.13.1",

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -811,7 +811,6 @@ export function run(options: Options) {
     );
     const brand = ts.createExpressionWithTypeArguments(
       [
-        ts.createTypeReferenceNode(ts.createIdentifier('never'), []),
         ts.createTypeReferenceNode(ts.createIdentifier('BrandOf' + oautil.typenamify(key)), [])
       ],
       ts.createPropertyAccess(runtimeLibrary, 'valueClass.ValueClass')

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -810,9 +810,7 @@ export function run(options: Options) {
       schema.additionalProperties
     );
     const brand = ts.createExpressionWithTypeArguments(
-      [
-        ts.createTypeReferenceNode(ts.createIdentifier('BrandOf' + oautil.typenamify(key)), [])
-      ],
+      [],
       ts.createPropertyAccess(runtimeLibrary, 'valueClass.ValueClass')
     );
     return ts.createClassDeclaration(
@@ -1423,7 +1421,6 @@ export function run(options: Options) {
     }
     return [
       generateTypeShape(key),
-      generateBrand(key),
       generateValueClass(key, schema),
       generateTopLevelClassBuilder(key, schema),
       generateTopLevelClassMaker(key),

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,10 +674,10 @@
   resolved "https://registry.yarnpkg.com/@smartlyio/oats-koa-adapter/-/oats-koa-adapter-2.2.0.tgz#9eea5de87c3a840aef89fa44d986b2405f4dd6f4"
   integrity sha512-ojny69UgR5JQx4N1+/rYR7EADLzQ55wLT9Jriac9k+GHp4Z4dNxMVJkXDvXkas1zoL5J+zOXoHL4noyB5ge+fg==
 
-"@smartlyio/oats-runtime@2.12.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.12.1.tgz#e68d5c3d1061cd590df20fbefd8374948dabe5eb"
-  integrity sha512-byruQTtkh/FCJRnMuuKM3polw5hN1rO7hYwHla7zhjorootoMLgIZlf7vSdhXxt40aNJYHoePW9L3Ia2XoB2yw==
+"@smartlyio/oats-runtime@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats-runtime/-/oats-runtime-2.13.0.tgz#3d1aaf469f463ad9cd59307ceda3a3852a25c2e4"
+  integrity sha512-Q2NHz/KrHbcfVmX5hLI3IhW/EQ2fCuMfF6z9V/cqUWYNmnlAB91LCSa4Zf2pMxpHtrZPD/2q7MnJXN1TfowJyw==
   dependencies:
     "@smartlyio/safe-navigation" "^5.0.1"
     lodash "^4.17.20"


### PR DESCRIPTION
https://github.com/smartlyio/oats-runtime/pull/143
either `oats-runtime` or `oats` is going to be have to be merged with failing CI since this change breaks both 😅