### PR TITLE
allow wildcard overlap with literal status code

### DIFF
--- a/src/status-codes.ts
+++ b/src/status-codes.ts
@@ -3,6 +3,10 @@ import * as assert from 'assert';
 export function resolvedStatusCodes(codes: string[]): Map<string, number[]> {
   const seen = new Set();
   codes.forEach(code => {
+    assert(
+      typeof code === 'string',
+      `HTTP status codes must be strings, got ${code} with type ${typeof code}`
+    );
     assert(!seen.has(code), `Duplicate status code ${code}`);
     assert(
       /^\dXX$/.test(code) || /^default$/.test(code) || /^\d\d\d$/.test(code),

--- a/src/status-codes.ts
+++ b/src/status-codes.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+
+export function resolvedStatusCodes(codes: string[]): Map<string, number[]> {
+  const seen = new Set();
+  codes.forEach(code => {
+    assert(!seen.has(code), `Duplicate status code ${code}`);
+    assert(
+      /^\dXX$/.test(code) || /^default$/.test(code) || /^\d\d\d$/.test(code),
+      `Malformed http status code ${code}`
+    );
+    seen.add(code);
+  });
+  const record = new Map();
+  const matchers: RegExp[] = codes.sort().map(c => {
+    if (c === 'default') {
+      return /.*/;
+    }
+    return new RegExp(c.replace(/XX$/, '..'));
+  });
+  for (const code of statusCodes) {
+    for (let i = 0; i < matchers.length; i++) {
+      const tester = matchers[i];
+      if (tester.test(String(code))) {
+        const existing = record.get(codes[i]);
+        if (existing) {
+          existing.push(code);
+        } else {
+          record.set(codes[i], [code]);
+        }
+        break;
+      }
+    }
+  }
+  return record;
+}
+
+const statusCodes = [
+  100,
+  200,
+  201,
+  202,
+  204,
+  206,
+  301,
+  302,
+  303,
+  304,
+  307,
+  308,
+  400,
+  401,
+  403,
+  404,
+  406,
+  407,
+  408,
+  410,
+  412,
+  416,
+  418,
+  425,
+  429,
+  451,
+  500,
+  501,
+  502,
+  503,
+  504
+];

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -75,6 +75,10 @@ paths:
             application/json:
               schema:
                 $ref: "common.yaml#/components/schemas/Item"
+        404:
+          description: not found
+        4XX:
+          description: some error
         default:
           description: error
           content:

--- a/test/status-codes.spec.ts
+++ b/test/status-codes.spec.ts
@@ -7,18 +7,27 @@ describe('statusCodes', () => {
     });
 
     it('allows wildcards', () => {
-      expect(statusCodes.resolvedStatusCodes(['2XX', '200'])).toEqual(
-        new Map([
-          ['200', [200]],
-          ['2XX', [201, 202, 204, 206]]
-        ])
-      );
+      const expected = new Map([
+        ['200', [200]],
+        ['2XX', [201, 202, 204, 206]]
+      ]);
+      expect(statusCodes.resolvedStatusCodes(['2XX', '200'])).toEqual(expected);
+      expect(statusCodes.resolvedStatusCodes(['200', '2XX'])).toEqual(expected);
     });
 
     it('sets defaults', () => {
-      const result = statusCodes.resolvedStatusCodes(['2XX', 'default']);
+      const result = statusCodes.resolvedStatusCodes(['default', '2XX', '200']);
       expect(result.get('default')?.length).toBeGreaterThan(0);
       expect(result.get('default')).not.toContain(200);
+
+      expect(statusCodes.resolvedStatusCodes(['200', '2XX', 'default'])).toEqual(result);
+    });
+
+    it('prevents incorrect status codes', () => {
+      expect(() => statusCodes.resolvedStatusCodes(['20X'])).toThrow();
+      expect(() => statusCodes.resolvedStatusCodes([200 as any])).toThrow();
+      expect(() => statusCodes.resolvedStatusCodes(['foo'])).toThrow();
+      expect(() => statusCodes.resolvedStatusCodes(['200', '200'])).toThrow();
     });
   });
 });

--- a/test/status-codes.spec.ts
+++ b/test/status-codes.spec.ts
@@ -1,0 +1,24 @@
+import * as statusCodes from '../src/status-codes';
+
+describe('statusCodes', () => {
+  describe('resolveStatusCodes', () => {
+    it('produces status codes indexed by key', () => {
+      expect(statusCodes.resolvedStatusCodes(['200'])).toEqual(new Map([['200', [200]]]));
+    });
+
+    it('allows wildcards', () => {
+      expect(statusCodes.resolvedStatusCodes(['2XX', '200'])).toEqual(
+        new Map([
+          ['200', [200]],
+          ['2XX', [201, 202, 204, 206]]
+        ])
+      );
+    });
+
+    it('sets defaults', () => {
+      const result = statusCodes.resolvedStatusCodes(['2XX', 'default']);
+      expect(result.get('default')?.length).toBeGreaterThan(0);
+      expect(result.get('default')).not.toContain(200);
+    });
+  });
+});


### PR DESCRIPTION
see https://swagger.io/specification/

fixes https://github.com/smartlyio/oats/issues/211