### PR TITLE
Add "success" status code, meaning 200 or 304

### DIFF
--- a/src/status-codes.ts
+++ b/src/status-codes.ts
@@ -9,7 +9,10 @@ export function resolvedStatusCodes(codes: string[]): Map<string, number[]> {
     );
     assert(!seen.has(code), `Duplicate status code ${code}`);
     assert(
-      /^\dXX$/.test(code) || /^default$/.test(code) || /^\d\d\d$/.test(code),
+      /^\dXX$/.test(code) ||
+        /^default$/.test(code) ||
+        /^success$/.test(code) ||
+        /^\d\d\d$/.test(code),
       `Malformed http status code ${code}`
     );
     seen.add(code);
@@ -18,6 +21,9 @@ export function resolvedStatusCodes(codes: string[]): Map<string, number[]> {
   const matchers: RegExp[] = codes.sort().map(c => {
     if (c === 'default') {
       return /.*/;
+    }
+    if (c === 'success') {
+      return /(200|304)/;
     }
     return new RegExp(c.replace(/XX$/, '..'));
   });

--- a/test/status-codes.spec.ts
+++ b/test/status-codes.spec.ts
@@ -23,6 +23,11 @@ describe('statusCodes', () => {
       expect(statusCodes.resolvedStatusCodes(['200', '2XX', 'default'])).toEqual(result);
     });
 
+    it('resolves a "success" status code, meaning 200 or 304', () => {
+      const expected = new Map([['success', [200, 304]]]);
+      expect(statusCodes.resolvedStatusCodes(['success'])).toEqual(expected);
+    });
+
     it('prevents incorrect status codes', () => {
       expect(() => statusCodes.resolvedStatusCodes(['20X'])).toThrow();
       expect(() => statusCodes.resolvedStatusCodes([200 as any])).toThrow();


### PR DESCRIPTION
We want to be able to match all successful status codes, which for now means 200 or 304 ("not modified"). Some of our internal services at Smartly.io implement 304, so it's nice to have a convenient way to do this.