### PR TITLE
Update oats-koa-adapter peer dependency version

### DIFF
--- a/packages/oats-koa-adapter/package.json
+++ b/packages/oats-koa-adapter/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^2.17.0",
+    "@smartlyio/oats-runtime": "^3.1.1",
     "koa": "^2.3.0",
     "koa-body": "^4.0.4",
     "koa-router": "^10.0.0",


### PR DESCRIPTION
Removes the following warning

```
yarn install v1.22.11
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
warning " > @smartlyio/oats-koa-adapter@3.1.1" has incorrect peer dependency "@smartlyio/oats-runtime@^2.17.0".
```