### PR TITLE
feat: implement `convert` option for transforming integer and number types from string to number

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ import * as runtime from '@smartlyio/oats-runtime';
 import * as app from './server';
 import * as assert from 'assert';
 
+runtime.make.registerFormat('name-format', value => runtime.make.Make.ok(value));
+
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(axiosAdapter.bind);

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -5,6 +5,8 @@ import * as runtime from '@smartlyio/oats-runtime';
 import * as app from './server';
 import * as assert from 'assert';
 
+runtime.make.registerFormat('name-format', value => runtime.make.Make.ok(value));
+
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(axiosAdapter.bind);

--- a/packages/oats-runtime/src/reflection-type.ts
+++ b/packages/oats-runtime/src/reflection-type.ts
@@ -70,6 +70,7 @@ export interface NumberType {
   readonly enum?: number[];
   readonly minimum?: number;
   readonly maximum?: number;
+  readonly convert?: boolean;
 }
 
 export interface IntegerType {
@@ -77,6 +78,7 @@ export interface IntegerType {
   readonly enum?: number[];
   readonly minimum?: number;
   readonly maximum?: number;
+  readonly convert?: boolean;
 }
 
 export interface ArrayType {

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -166,8 +166,12 @@ export function safe<
       servers: ctx.servers,
       op: ctx.op,
       headers: cleanHeaders(headers, ctx.headers),
-      params: params(voidify(ctx.params)).success(throwRequestValidationError.bind(null, 'params')),
-      query: query(ctx.query || {}).success(throwRequestValidationError.bind(null, 'query')),
+      params: params(voidify(ctx.params), { defaultConvert: true }).success(
+        throwRequestValidationError.bind(null, 'params')
+      ),
+      query: query(ctx.query || {}, { defaultConvert: true }).success(
+        throwRequestValidationError.bind(null, 'query')
+      ),
       body: body(voidify(ctx.body)).success(throwRequestValidationError.bind(null, 'body')),
       requestContext: ctx.requestContext as any
     });

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -253,13 +253,12 @@ describe('string', () => {
     );
   });
 
-  it('accepts if format is not defined', () => {
+  it('rejects if format is not defined', () => {
     const type: Type = {
       type: 'string',
       format: 'some-format'
     };
-    const fun = make.fromReflection(type);
-    fun('b').success();
+    expect(() => make.fromReflection(type)).toThrow('format "some-format" is not registered.');
   });
 
   it('rejects if format rejects', () => {
@@ -329,6 +328,22 @@ describe('number', () => {
     expect(fun(4).errors[0].error).toMatch('expected a number smaller than');
     expect(fun(3).isSuccess()).toBeTruthy();
   });
+  it('requires number to be integer', () => {
+    const fun = make.fromReflection({ type: 'integer', minimum: 1 });
+    expect(fun(1.5).errors[0].error).toMatch('expected an integer');
+    expect(fun(123).success()).toBe(123);
+  });
+  it('converts string to integer', () => {
+    const fun1 = make.fromReflection({ type: 'integer' });
+    expect(fun1('123', { defaultConvert: true }).success()).toBe(123);
+    expect(fun1('123').isError()).toBe(true);
+
+    const fun2 = make.fromReflection({ type: 'number', convert: false });
+    expect(fun2('12345', { defaultConvert: true }).isError()).toBe(true);
+
+    const fun3 = make.fromReflection({ type: 'number', convert: true });
+    expect(fun3('12345', { defaultConvert: false }).success()).toBe(12345);
+  });
 });
 
 describe('array', () => {
@@ -372,7 +387,7 @@ describe('object', () => {
         properties: {},
         additionalProperties: { type: 'unknown' }
       });
-      expect(fun([]).errors[0].error).toEqual('expected an object, but got "[]" instead.');
+      expect(fun([]).errors[0].error).toEqual('expected an object, but got `[]` instead.');
     });
 
     it('disallows constructor', () => {

--- a/packages/oats-runtime/test/make.spec.ts
+++ b/packages/oats-runtime/test/make.spec.ts
@@ -44,7 +44,7 @@ describe('makeOneOf', () => {
     expect(result.errors.length).toEqual(1);
     const expected = `root: no option of oneOf matched
     - option 1
-        a: expected a string, but got "undefined" instead.
+        a: expected a string, but got \`undefined\` instead.
     - option 2
         foo: unexpected property`;
     expect(validationErrorPrinter(result.errors[0])).toEqual(expected);

--- a/packages/oats-runtime/test/server.spec.ts
+++ b/packages/oats-runtime/test/server.spec.ts
@@ -15,7 +15,7 @@ describe('safe', () => {
     const endpoint = server.safe<any, any, any, any, any, any>(
       makeVoid(),
       makeVoid(),
-      makeObject({ param: makeNumber() }) as Maker<any, any>,
+      makeObject({ param: makeNumber(false) }) as Maker<any, any>,
       makeVoid(),
       makeObject({
         status: makeEnum(200),
@@ -49,7 +49,7 @@ describe('safe', () => {
     const endpoint = server.safe<any, any, any, any, any, any>(
       makeVoid(),
       makeVoid(),
-      makeObject({ param: makeNumber() }) as Maker<any, any>,
+      makeObject({ param: makeNumber(false) }) as Maker<any, any>,
       makeArray(makeString()),
       makeObject({
         status: makeEnum(200),

--- a/packages/oats/README.md
+++ b/packages/oats/README.md
@@ -205,6 +205,8 @@ import * as runtime from '@smartlyio/oats-runtime';
 import * as app from './server';
 import * as assert from 'assert';
 
+runtime.make.registerFormat('name-format', value => runtime.make.Make.ok(value));
+
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(axiosAdapter.bind);

--- a/packages/oats/examples/client.ts
+++ b/packages/oats/examples/client.ts
@@ -5,6 +5,8 @@ import * as runtime from '@smartlyio/oats-runtime';
 import * as app from './server';
 import * as assert from 'assert';
 
+runtime.make.registerFormat('name-format', value => runtime.make.Make.ok(value));
+
 // 'api.client' is the abstract implementation of the client which is then
 // mapped to axios requests using 'axiosAdapter'
 const apiClient = api.client(axiosAdapter.bind);

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -915,7 +915,7 @@ export function run(options: Options) {
         true
       );
     }
-    if (schema.type === 'number') {
+    if (schema.type === 'number' || schema.type === 'integer') {
       const enumValues = schema.enum
         ? [
             ts.createPropertyAssignment(
@@ -925,7 +925,7 @@ export function run(options: Options) {
           ]
         : [];
       const properties = [
-        ts.createPropertyAssignment('type', ts.createStringLiteral('number')),
+        ts.createPropertyAssignment('type', ts.createStringLiteral(schema.type)),
         ...enumValues
       ];
       if (schema.minimum != null) {
@@ -938,32 +938,12 @@ export function run(options: Options) {
           ts.createPropertyAssignment('maximum', ts.createNumericLiteral(schema.maximum + ''))
         );
       }
-      return ts.createObjectLiteral(properties, true);
-    }
-    if (schema.type === 'integer') {
-      const enumValues = schema.enum
-        ? [
-            ts.createPropertyAssignment(
-              'enum',
-              ts.createArrayLiteral(schema.enum.map(i => ts.createNumericLiteral('' + i)))
-            )
-          ]
-        : [];
-      const properties = [
-        ts.createPropertyAssignment('type', ts.createStringLiteral('integer')),
-        ...enumValues
-      ];
-      if (schema.minimum != null) {
+      if (schema.convert != null) {
+        assert(typeof schema.convert === 'boolean', '"convert" must be a boolean');
         properties.push(
-          ts.createPropertyAssignment('minimum', ts.createNumericLiteral(schema.minimum + ''))
+          ts.createPropertyAssignment('convert', schema.convert ? ts.createTrue() : ts.createFalse())
         );
       }
-      if (schema.maximum != null) {
-        properties.push(
-          ts.createPropertyAssignment('maximum', ts.createNumericLiteral(schema.maximum + ''))
-        );
-      }
-
       return ts.createObjectLiteral(properties, true);
     }
     if (schema.type === 'boolean') {


### PR DESCRIPTION
BREAKING CHANGE number and integer types are by default converted for path and query parameters

BREAKING CHANGE format option in a schema requires format to be registered with `runtime.make.registerFormat()`

BREAKING CHANGE integer type asserts value is an integer

BREAKING CHANGE change `runtime.make.makeNumber()` signature - first argument is `isInteger: boolean`
