### PR TITLE
fix throw when child union had untagged members

### DIFF
--- a/packages/oats-runtime/src/union-discriminator.ts
+++ b/packages/oats-runtime/src/union-discriminator.ts
@@ -4,7 +4,7 @@ export function intersectMap(a: Map<string, any>, b: Map<string, any>): Map<stri
   const result = new Map();
   for (const [key, values] of a) {
     const gots = b.get(key);
-    if (arrayEq(gots, values)) {
+    if (gots && values && arrayEq(gots, values)) {
       result.set(key, values);
     }
   }

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -4,6 +4,40 @@ import { TestClass } from './test-class';
 import { Type } from '../src/reflection-type';
 
 describe('union differentation', () => {
+  it('handles cases where union children are missing the tag', () => {
+    const atype: Type = {
+      type: 'union',
+      options: [
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            tag: {
+              value: {
+                type: 'string',
+                enum: ['b']
+              },
+              required: true
+            }
+          }
+        },
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            val: {
+              value: { type: 'string' },
+              required: true
+            }
+          }
+        }
+      ]
+    };
+    const fun = make.fromReflection({ type: 'union', options: [atype] });
+    expect(fun({ tag: 'b' }).success()).toEqual({ tag: 'b' });
+    expect(fun({ val: 'something' }).success()).toEqual({ val: 'something' });
+  });
+
   it('uses discriminator to build values allowing unions as children', () => {
     const atype: Type = {
       type: 'union',


### PR DESCRIPTION
when we had nested oneofs where the leaf oneOfs children some had properties usable for tagging and some did not  (ie some children had enum props and some did not) we ended up throwing because typescript is a lie