### PR TITLE
Be even more inclusive when checking string length

### DIFF
--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -174,13 +174,13 @@ export function makeString(
     if (typeof value !== 'string') {
       return getErrorWithValueMsg('expected a string', value);
     }
-    if (minLength != null && value.length <= minLength) {
+    if (minLength != null && value.length < minLength) {
       return getErrorWithValueMsg(
         'expected a string with a length of at least ' + minLength,
         value
       );
     }
-    if (maxLength != null && value.length >= maxLength) {
+    if (maxLength != null && value.length > maxLength) {
       return getErrorWithValueMsg(
         'expected a string with a length of at maximum ' + maxLength,
         value

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -250,12 +250,14 @@ describe('string', () => {
   it('enforces minimum length if passed', () => {
     const fun = make.fromReflection({ type: 'string', minLength: 3 });
     expect(fun('a').errors[0].error).toMatch('expected a string with a length of at least');
+    expect(fun('abc').isSuccess()).toBeTruthy();
     expect(fun('abcd').isSuccess()).toBeTruthy();
   });
 
   it('enforces maximum length if passed', () => {
     const fun = make.fromReflection({ type: 'string', maxLength: 3 });
     expect(fun('abcd').errors[0].error).toMatch('expected a string with a length of at maximum');
+    expect(fun('abc').isSuccess()).toBeTruthy();
     expect(fun('a').isSuccess()).toBeTruthy();
   });
 


### PR DESCRIPTION
String `minLength`/`maxLength` limit should be inclusive

Smartly v1 openapi definitions contain
```
country:
      description: Country code according to ISO 3166-1 alpha-2
      type: string
      minLength: 2
      maxLength: 2
```
