### PR TITLE
allow passing middlewares to koa router endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.1
+
+Allow passing middlewares to oats-koa-adapter in `bind`. The middlewares are applied to all specified endpoints.
+
 # 3.4.0
 
 oats-koa-adapter does not anymore set status code 204 when no content is set in response body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.4.1
+# 3.5.0
 
 Allow passing middlewares to oats-koa-adapter in `bind`. The middlewares are applied to all specified endpoints.
 

--- a/packages/oats-koa-adapter/README.md
+++ b/packages/oats-koa-adapter/README.md
@@ -13,7 +13,7 @@ Oats Koa Adapter is a library that binds server endpoints written with [Oats](ht
 Use `npm` or `yarn` to install `oats-koa-adapter`.
 
 ```bash
-npm install oats-koa-adapter
+npm install @smartlyio/oats-koa-adapter
 ```
 
 ## Usage
@@ -33,8 +33,15 @@ import spec from '<Your Route Definitions>';
 export const router = () => {
   const requestContextCreator = (ctx: any): any => ctx;
 
-  const oatsRouter = koaAdapter.bind(oaserver.createRouter(), spec, requestContextCreator);
-
+  const middlewares = [(_ctx, next) => { return next() }];
+  
+  const oatsRouter = koaAdapter.bind({ 
+    handler: oaserver.createRouter(), 
+    spec, 
+    requestContextCreator,
+    middlewares
+  });
+  
   return new Router().use(oatsRouter.routes())
 };
 

--- a/packages/oats-koa-adapter/README.template.md
+++ b/packages/oats-koa-adapter/README.template.md
@@ -13,7 +13,7 @@ Oats Koa Adapter is a library that binds server endpoints written with [Oats](ht
 Use `npm` or `yarn` to install `oats-koa-adapter`.
 
 ```bash
-npm install oats-koa-adapter
+npm install @smartlyio/oats-koa-adapter
 ```
 
 ## Usage
@@ -33,8 +33,15 @@ import spec from '<Your Route Definitions>';
 export const router = () => {
   const requestContextCreator = (ctx: any): any => ctx;
 
-  const oatsRouter = koaAdapter.bind(oaserver.createRouter(), spec, requestContextCreator);
-
+  const middlewares = [(_ctx, next) => { return next() }];
+  
+  const oatsRouter = koaAdapter.bind({ 
+    handler: oaserver.createRouter(), 
+    spec, 
+    requestContextCreator,
+    middlewares
+  });
+  
   return new Router().use(oatsRouter.routes())
 };
 

--- a/packages/oats-koa-adapter/index.ts
+++ b/packages/oats-koa-adapter/index.ts
@@ -1,10 +1,13 @@
 import * as Router from 'koa-router';
 import { ParameterizedContext } from 'koa';
 import * as runtime from '@smartlyio/oats-runtime';
+import * as assert from 'assert';
+import { IMiddleware } from 'koa-router';
 
 function adapter<StateT, CustomT, RequestContext>(
   router: Router<StateT, CustomT>,
-  requestContextCreator: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext
+  requestContextCreator: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext,
+  middlewares: Array<IMiddleware<any, any>>
 ): runtime.server.ServerAdapter {
   return (
     path: string,
@@ -13,61 +16,83 @@ function adapter<StateT, CustomT, RequestContext>(
     handler: runtime.server.SafeEndpoint
   ) => {
     const koaPath = path.replace(/{([^}]+)}/g, (m, param) => ':' + param);
-    (router as any)[method](koaPath, async (ctx: ParameterizedContext<StateT, CustomT>) => {
-      const files = (ctx as any).request.files;
-      let fileFields = {};
-      if (files) {
-        fileFields = Object.keys(files).reduce((memo: any, name) => {
-          memo[name] = new runtime.make.File(files[name].path, files[name].size, files[name].name);
-          return memo;
-        }, {});
-      }
-      const contentType = ctx.request.type;
-      const requestBody = (ctx.request as any).body;
-      let body;
+    (router as any)[method](
+      koaPath,
+      ...middlewares,
+      async (ctx: ParameterizedContext<StateT, CustomT>) => {
+        const files = (ctx as any).request.files;
+        let fileFields = {};
+        if (files) {
+          fileFields = Object.keys(files).reduce((memo: any, name) => {
+            memo[name] = new runtime.make.File(
+              files[name].path,
+              files[name].size,
+              files[name].name
+            );
+            return memo;
+          }, {});
+        }
+        const contentType = ctx.request.type;
+        const requestBody = (ctx.request as any).body;
+        let body;
 
-      if (Array.isArray(requestBody)) {
-        body = { value: requestBody, contentType };
-      } else if (typeof requestBody === 'object') {
-        const bodyWithFileFields = { ...requestBody, ...fileFields };
-        body =
-          Object.keys(bodyWithFileFields).length > 0
-            ? { value: bodyWithFileFields, contentType }
-            : undefined;
-      }
+        if (Array.isArray(requestBody)) {
+          body = { value: requestBody, contentType };
+        } else if (typeof requestBody === 'object') {
+          const bodyWithFileFields = { ...requestBody, ...fileFields };
+          body =
+            Object.keys(bodyWithFileFields).length > 0
+              ? { value: bodyWithFileFields, contentType }
+              : undefined;
+        }
 
-      const result = await handler({
-        path,
-        method: runtime.server.assertMethod(ctx.method.toLowerCase()),
-        servers: [],
-        op,
-        headers: ctx.request.headers,
-        params: (ctx as any).params,
-        query: ctx.query,
-        body,
-        requestContext: requestContextCreator(ctx)
-      });
-      ctx.body = result.value.value;
-      ctx.status = result.status;
-      ctx.set(result.headers);
-    });
+        const result = await handler({
+          path,
+          method: runtime.server.assertMethod(ctx.method.toLowerCase()),
+          servers: [],
+          op,
+          headers: ctx.request.headers,
+          params: (ctx as any).params,
+          query: ctx.query,
+          body,
+          requestContext: requestContextCreator(ctx)
+        });
+        ctx.body = result.value.value;
+        ctx.status = result.status;
+        ctx.set(result.headers);
+      }
+    );
   };
 }
+
+type Opts<Spec, StateT, CustomT, RequestContext> = {
+  handler: runtime.server.HandlerFactory<Spec>;
+  spec: Spec;
+  requestContextCreator?: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext;
+  middlewares?: Array<IMiddleware<any, any>>;
+};
 
 /**
  * Bind provided handlers for the OpenAPI routes
  *
  * Koa's default StateT and CustomT values are selected as defaults
- * @param handler
- * @param spec
- * @param requestContextCreator
+ * @param opts Named arguments to the function
+ * @param spec Deprecated use the named arguments
+ * @param requestContextCreator Deprecated
  */
 export function bind<Spec, RequestContext = void, StateT = any, CustomT = Record<string, unknown>>(
-  handler: runtime.server.HandlerFactory<Spec>,
-  spec: Spec,
+  opts: runtime.server.HandlerFactory<Spec> | Opts<Spec, StateT, CustomT, RequestContext>,
+  spec?: Spec,
   requestContextCreator?: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext
 ): Router<StateT, CustomT> {
+  const arg =
+    typeof opts === 'function'
+      ? { handler: opts, spec, requestContextCreator, middlewares: [] }
+      : opts;
+  assert(arg.spec, 'Missing spec argument -- please use the named argument version of bind');
   const router = new Router<StateT, CustomT>();
-  handler(adapter(router, requestContextCreator || (() => ({}))))(spec);
+  arg.handler(adapter(router, arg.requestContextCreator || (() => ({})), arg.middlewares || []))(
+    arg.spec
+  );
   return router;
 }

--- a/packages/oats-koa-adapter/index.ts
+++ b/packages/oats-koa-adapter/index.ts
@@ -7,7 +7,7 @@ import { IMiddleware } from 'koa-router';
 function adapter<StateT, CustomT, RequestContext>(
   router: Router<StateT, CustomT>,
   requestContextCreator: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext,
-  middlewares: Array<IMiddleware<any, any>>
+  middlewares: Array<IMiddleware<StateT, CustomT>>
 ): runtime.server.ServerAdapter {
   return (
     path: string,
@@ -69,7 +69,7 @@ type Opts<Spec, StateT, CustomT, RequestContext> = {
   handler: runtime.server.HandlerFactory<Spec>;
   spec: Spec;
   requestContextCreator?: (ctx: ParameterizedContext<StateT, CustomT>) => RequestContext;
-  middlewares?: Array<IMiddleware<any, any>>;
+  middlewares?: Array<IMiddleware<StateT, CustomT>>;
 };
 
 /**


### PR DESCRIPTION
- change signature of koa adapter bind to be named arguments as the there are already a bunch of arguments
- allow passing a list of middlewares that get applied to all endpoints defined in bind `spec` (note: not all possible endpoints just the one you have defined a handler for)