### PR TITLE
Support cyclical dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+
+# 4.0.0
+
+Fix cyclical imports and lose the need for `Object.assign` in the generated types.
+
+## Breaking changes:
+Type of `reference` in named reflection nodes has changed to `() => ...`
+Type of `reflection` in `ValueClass` classes has changed to `() => ...`
+
 # 3.5.0
 
 Allow passing middlewares to oats-koa-adapter in `bind`. The middlewares are applied to all specified endpoints.

--- a/packages/oats-fast-check/src/generator.ts
+++ b/packages/oats-fast-check/src/generator.ts
@@ -67,7 +67,7 @@ export class GenType extends fc.Arbitrary<any> {
       assert.fail('todo intersection value generation');
     }
     if (type.type === 'named') {
-      return named(type.reference);
+      return named(type.reference());
     }
     if (type.type === 'null') {
       return fc.constant(null);

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -484,7 +484,7 @@ export function makeNullable(maker: any) {
 
 function isScalar(type: Type): boolean {
   if (type.type === 'named') {
-    return isScalar(type.reference.definition);
+    return isScalar(type.reference().definition);
   }
   return ['array', 'object', 'union', 'intersection', 'unknown'].indexOf(type.type) < 0;
 }
@@ -494,7 +494,7 @@ function enumOptions(type: Type): number | null {
     return 1;
   }
   if (type.type === 'named') {
-    return enumOptions(type.reference.definition);
+    return enumOptions(type.reference().definition);
   }
   if (
     type.type === 'string' ||
@@ -622,7 +622,7 @@ export function fromReflection(type: Type): Maker<any, any> {
     case 'intersection':
       return makeAllOf(...type.options.map(req => fromReflection(req)));
     case 'named':
-      return type.reference.maker;
+      return type.reference().maker;
     case 'unknown':
       return makeAny();
     case 'binary':
@@ -683,7 +683,7 @@ export function extractDiscriminatorKeys(
   typeObjectRef: Type
 ): string[] {
   const typeObject =
-    typeObjectRef.type === 'named' ? typeObjectRef.reference.definition : typeObjectRef;
+    typeObjectRef.type === 'named' ? typeObjectRef.reference().definition : typeObjectRef;
 
   if (typeObject.type === 'union') {
     const keys = typeObject.options.map(type => extractDiscriminatorKeys(discriminatorField, type));
@@ -700,7 +700,7 @@ export function extractDiscriminatorKeys(
   }
   const fieldSchemaRef = typeObject.properties[discriminatorField].value;
   const fieldSchema =
-    fieldSchemaRef.type === 'named' ? fieldSchemaRef.reference.definition : fieldSchemaRef;
+    fieldSchemaRef.type === 'named' ? fieldSchemaRef.reference().definition : fieldSchemaRef;
 
   if (fieldSchema.type === 'union') {
     return extractDiscriminatorKeys(discriminatorField, fieldSchemaRef);

--- a/packages/oats-runtime/src/reflection-type.ts
+++ b/packages/oats-runtime/src/reflection-type.ts
@@ -18,6 +18,8 @@ export type Type =
   | ObjectType
   | NamedType;
 
+export type NamedTypeDefinitionDeferred<A, Shape = any> = () => NamedTypeDefinition<A, Shape>;
+
 export interface NamedTypeDefinition<A, Shape = any> {
   readonly name: string;
   readonly definition: Type;
@@ -88,7 +90,7 @@ export interface ArrayType {
 
 export interface NamedType {
   readonly type: 'named';
-  readonly reference: NamedTypeDefinition<unknown>;
+  readonly reference: NamedTypeDefinitionDeferred<unknown>;
 }
 
 export interface PropType {
@@ -348,8 +350,8 @@ function calculateReachInType(
   ambiguousPath: boolean
 ) {
   if (type.type === 'named') {
-    canReach(reaches, from, type.reference, path);
-    calculateReverseReach(processed, reaches, type.reference, to, ambiguousPath);
+    canReach(reaches, from, type.reference(), path);
+    calculateReverseReach(processed, reaches, type.reference(), to, ambiguousPath);
   } else if (type.type === 'array') {
     calculateReachInType(
       processed,

--- a/packages/oats-runtime/src/union-discriminator.ts
+++ b/packages/oats-runtime/src/union-discriminator.ts
@@ -49,14 +49,14 @@ export function getTags(type: Type): Map<string, unknown[]> {
 
 function rootType(type: Type): Type {
   if (type.type === 'named') {
-    return rootType(type.reference.definition);
+    return rootType(type.reference().definition);
   }
   return type;
 }
 
 function typeTag(v: Type): unknown[] {
   if (v.type === 'named') {
-    return typeTag(v.reference.definition);
+    return typeTag(v.reference().definition);
   }
   if (v.type === 'string' || v.type === 'boolean' || v.type === 'number' || v.type === 'integer') {
     if (v.enum) {

--- a/packages/oats-runtime/src/value-class.ts
+++ b/packages/oats-runtime/src/value-class.ts
@@ -1,4 +1,4 @@
-import { NamedTypeDefinition } from './reflection-type';
+import { NamedTypeDefinitionDeferred } from './reflection-type';
 import { ShapeOf } from './runtime';
 
 function asPlainObject(value: any): any {
@@ -15,7 +15,7 @@ function asPlainObject(value: any): any {
 }
 
 export class ValueClass {
-  public static reflection: NamedTypeDefinition<ValueClass>;
+  public static reflection: NamedTypeDefinitionDeferred<ValueClass>;
 }
 
 type WritableArray<T> = Array<Writable<T>>;

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -96,7 +96,7 @@ describe('union differentation', () => {
         tag: {
           value: {
             type: 'named',
-            reference: {
+            reference: () => ({
               name: 'a',
               isA: 1 as any,
               maker: 1 as any,
@@ -104,7 +104,7 @@ describe('union differentation', () => {
                 type: 'string',
                 enum: ['a']
               }
-            }
+            })
           },
           required: true
         }
@@ -112,7 +112,7 @@ describe('union differentation', () => {
     };
     const btype: Type = {
       type: 'named',
-      reference: {
+      reference: () => ({
         maker: make.fromReflection({
           type: 'object',
           additionalProperties: false,
@@ -129,7 +129,7 @@ describe('union differentation', () => {
             tag: { value: { type: 'string', enum: ['b'] }, required: true }
           }
         }
-      }
+      })
     };
     const fun = make.fromReflection({ type: 'union', options: [atype, btype] });
     expect(fun({ tag: 'b' }).success()).toEqual({ tag: 'b' });
@@ -140,12 +140,12 @@ describe('named', () => {
   it('uses the maker from name', () => {
     const type: Type = {
       type: 'named',
-      reference: {
+      reference: () => ({
         name: 'aa',
         definition: 1 as any,
         isA: 1 as any,
         maker: make.fromReflection({ type: 'string' })
-      }
+      })
     };
     const fun = make.fromReflection(type);
     const result = fun('aaa').success();
@@ -183,12 +183,12 @@ describe('union', () => {
         },
         {
           type: 'named',
-          reference: {
+          reference: () => ({
             name: 'aa',
             definition: 1 as any,
             isA: 1 as any,
             maker: TestClass.make
-          }
+          })
         }
       ]
     };
@@ -206,21 +206,21 @@ describe('union', () => {
         },
         {
           type: 'named',
-          reference: {
+          reference: () => ({
             name: 'aa',
             definition: 1 as any,
             isA: 1 as any,
             maker: TestClass.make
-          }
+          })
         },
         {
           type: 'named',
-          reference: {
+          reference: () => ({
             name: 'aa',
             definition: 1 as any,
             isA: 1 as any,
             maker: TestClass.make
-          }
+          })
         }
       ]
     };

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -833,18 +833,17 @@ export function run(options: Options) {
       return ts.createObjectLiteral(
         [
           ts.createPropertyAssignment('type', ts.createStringLiteral('named')),
-          ts.createPropertyAssignment('reference',
+          ts.createPropertyAssignment(
+            'reference',
             ts.factory.createArrowFunction(
               undefined,
               undefined,
               [],
               undefined,
               ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              ts.factory.createBlock(
-                [ts.factory.createReturnStatement(type)],
-                false
-              )
-            ))
+              ts.factory.createBlock([ts.factory.createReturnStatement(type)], false)
+            )
+          )
         ],
         true
       );
@@ -1075,7 +1074,7 @@ export function run(options: Options) {
       return generateIsA(options.nameMapper(key, 'value'));
     }
     if (isScalar(schema)) {
-        return generateIsAForScalar(key);
+      return generateIsAForScalar(key);
     }
   }
 
@@ -1094,9 +1093,15 @@ export function run(options: Options) {
             ts.createAsExpression(
               ts.createObjectLiteral(
                 [
-                  ts.createPropertyAssignment('name', ts.createStringLiteral(options.nameMapper(key, 'value'))),
+                  ts.createPropertyAssignment(
+                    'name',
+                    ts.createStringLiteral(options.nameMapper(key, 'value'))
+                  ),
                   ts.createPropertyAssignment('definition', generateReflectionType(schema)),
-                  ts.createPropertyAssignment('maker', ts.createIdentifier('make' + options.nameMapper(key, 'value'))),
+                  ts.createPropertyAssignment(
+                    'maker',
+                    ts.createIdentifier('make' + options.nameMapper(key, 'value'))
+                  ),
                   ts.createPropertyAssignment('isA', isA ?? ts.createNull())
                 ],
                 true
@@ -1266,7 +1271,7 @@ export function run(options: Options) {
         ),
         generateTypeShape(key, valueIdentifier),
         generateTopLevelMaker(key, schema),
-        generateNamedTypeDefinitionDeclaration(key, schema),
+        generateNamedTypeDefinitionDeclaration(key, schema)
       ];
     }
 
@@ -1280,7 +1285,7 @@ export function run(options: Options) {
       ),
       generateTypeShape(key, valueIdentifier),
       generateTopLevelMaker(key, schema),
-      generateNamedTypeDefinitionDeclaration(key, schema),
+      generateNamedTypeDefinitionDeclaration(key, schema)
     ];
   }
 
@@ -1338,14 +1343,9 @@ export function run(options: Options) {
       Object.keys(components).map(key => {
         const component = components[key];
         const schema = oautil.isReferenceObject(component)
-            ? { $ref: component.$ref }
-            : generateContentSchemaType(component.content || assert.fail('missing content'))
-        nodes.push(
-          ...generateTopLevelType(
-            key,
-            schema
-          )
-        )
+          ? { $ref: component.$ref }
+          : generateContentSchemaType(component.content || assert.fail('missing content'));
+        nodes.push(...generateTopLevelType(key, schema));
       });
     }
     return nodes;

--- a/test/cyclical-dependencies/cyclical.spec.ts
+++ b/test/cyclical-dependencies/cyclical.spec.ts
@@ -1,0 +1,19 @@
+import * as first from './tmp/first.types.generated';
+
+describe('cyclical test', () => {
+  it('allows cyclically depending objects', () => {
+    expect(
+      first.typeFirstObject
+        .maker({
+          target: {
+            target: {
+              target: {}
+            }
+          }
+        })
+        .success()
+    ).toEqual({
+      target: { target: { target: {} } }
+    });
+  });
+});

--- a/test/cyclical-dependencies/driver.ts
+++ b/test/cyclical-dependencies/driver.ts
@@ -1,0 +1,11 @@
+import { driver } from '@smartlyio/oats';
+
+import * as process from 'process';
+process.chdir(__dirname);
+
+driver.generate({
+  generatedValueClassFile: './tmp/first.types.generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './first.yaml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});

--- a/test/cyclical-dependencies/first.yaml
+++ b/test/cyclical-dependencies/first.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: fixtures for runtime test
+paths: {}
+components:
+  schemas:
+    FirstObject:
+      type: object
+      properties:
+        target:
+          $ref: './second.yaml#/components/schemas/SecondObject'

--- a/test/cyclical-dependencies/second.yaml
+++ b/test/cyclical-dependencies/second.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: fixtures for runtime test
+paths: {}
+components:
+  schemas:
+    SecondObject:
+      type: object
+      properties:
+        target:
+          $ref: './first.yaml#/components/schemas/FirstObject'

--- a/test/reflection/reflection-type.spec.ts
+++ b/test/reflection/reflection-type.spec.ts
@@ -626,7 +626,7 @@ describe('reflection-type', () => {
               isA: (v): v is TestClass => v instanceof TestClass,
               definition: {
                 type: 'object',
-                additionalProperties: { type: 'named', reference: () =>target },
+                additionalProperties: { type: 'named', reference: () => target },
                 properties: {
                   field: { required: false, value: { type: 'string' } },
                   other: { required: false, value: { type: 'string' } }

--- a/test/reflection/reflection-type.spec.ts
+++ b/test/reflection/reflection-type.spec.ts
@@ -78,7 +78,7 @@ describe('reflection-type', () => {
         isA: null,
         definition: {
           type: 'array',
-          items: { type: 'named', reference: target }
+          items: { type: 'named', reference: () => target }
         }
       };
       const root: reflectionType.NamedTypeDefinition<any> = {
@@ -92,14 +92,14 @@ describe('reflection-type', () => {
             items: {
               value: {
                 type: 'named',
-                reference: middle
+                reference: () => middle
               },
               required: true
             },
             items2: {
               value: {
                 type: 'named',
-                reference: middle
+                reference: () => middle
               },
               required: true
             }
@@ -131,7 +131,7 @@ describe('reflection-type', () => {
         isA: null,
         definition: {
           type: 'named',
-          reference: target
+          reference: () => target
         }
       };
 
@@ -141,7 +141,7 @@ describe('reflection-type', () => {
         isA: null,
         definition: {
           type: 'named',
-          reference: middle2
+          reference: () => middle2
         }
       };
       const root: reflectionType.NamedTypeDefinition<any> = {
@@ -153,7 +153,7 @@ describe('reflection-type', () => {
           additionalProperties: false,
           properties: {
             item: {
-              value: { type: 'named', reference: middle },
+              value: { type: 'named', reference: () => middle },
               required: false
             }
           }
@@ -185,7 +185,7 @@ describe('reflection-type', () => {
             items: {
               value: {
                 type: 'array',
-                items: { type: 'named', reference: target }
+                items: { type: 'named', reference: () => target }
               },
               required: false
             }
@@ -208,7 +208,7 @@ describe('reflection-type', () => {
           additionalProperties: false,
           properties: {
             recursive: {
-              value: { type: 'named', reference: middle },
+              value: { type: 'named', reference: () => middle },
               required: false
             },
             noHit: {
@@ -218,7 +218,7 @@ describe('reflection-type', () => {
             middleField: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }]
+                options: [{ type: 'named', reference: () => target }]
               },
               required: false
             }
@@ -236,7 +236,7 @@ describe('reflection-type', () => {
             rootField: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: middle }]
+                options: [{ type: 'named', reference: () => middle }]
               },
               required: false
             }
@@ -276,7 +276,7 @@ describe('reflection-type', () => {
             middleField: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }]
+                options: [{ type: 'named', reference: () => target }]
               },
               required: false
             }
@@ -294,7 +294,7 @@ describe('reflection-type', () => {
             rootField: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: middle }]
+                options: [{ type: 'named', reference: () => middle }]
               },
               required: false
             }
@@ -322,7 +322,7 @@ describe('reflection-type', () => {
             field: {
               value: {
                 type: 'named',
-                reference: target
+                reference: () => target
               },
               required: false
             }
@@ -346,7 +346,7 @@ describe('reflection-type', () => {
             options: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }]
+                options: [{ type: 'named', reference: () => target }]
               },
               required: false
             }
@@ -368,14 +368,14 @@ describe('reflection-type', () => {
           additionalProperties: false,
           properties: {
             field: {
-              value: { type: 'named', reference: target },
+              value: { type: 'named', reference: () => target },
               required: false
             },
             ambiguous: {
               required: false,
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }, { type: 'string' }]
+                options: [{ type: 'named', reference: () => target }, { type: 'string' }]
               }
             }
           }
@@ -398,7 +398,7 @@ describe('reflection-type', () => {
             options: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }, { type: 'null' }]
+                options: [{ type: 'named', reference: () => target }, { type: 'null' }]
               },
               required: false
             }
@@ -420,7 +420,7 @@ describe('reflection-type', () => {
         isA: null,
         definition: {
           type: 'union',
-          options: [{ type: 'named', reference: target }]
+          options: [{ type: 'named', reference: () => target }]
         }
       };
       const root: reflectionType.NamedTypeDefinition<any> = {
@@ -432,7 +432,7 @@ describe('reflection-type', () => {
           additionalProperties: false,
           properties: {
             options: {
-              value: { type: 'named', reference: union },
+              value: { type: 'named', reference: () => union },
               required: false
             }
           }
@@ -474,7 +474,7 @@ describe('reflection-type', () => {
             options: {
               value: {
                 type: 'union',
-                options: [{ type: 'named', reference: target }, { type: 'string' }]
+                options: [{ type: 'named', reference: () => target }, { type: 'string' }]
               },
               required: false
             }
@@ -573,7 +573,7 @@ describe('reflection-type', () => {
                   field: {
                     value: {
                       type: 'named',
-                      reference: target
+                      reference: () => target
                     },
                     required: false
                   }
@@ -599,7 +599,7 @@ describe('reflection-type', () => {
                       type: 'array',
                       items: {
                         type: 'named',
-                        reference: target
+                        reference: () => target
                       }
                     },
                     required: false
@@ -626,7 +626,7 @@ describe('reflection-type', () => {
               isA: (v): v is TestClass => v instanceof TestClass,
               definition: {
                 type: 'object',
-                additionalProperties: { type: 'named', reference: target },
+                additionalProperties: { type: 'named', reference: () =>target },
                 properties: {
                   field: { required: false, value: { type: 'string' } },
                   other: { required: false, value: { type: 'string' } }
@@ -664,7 +664,7 @@ describe('reflection-type', () => {
                   field: {
                     value: {
                       type: 'named',
-                      reference: target
+                      reference: () => target
                     },
                     required: false
                   }


### PR DESCRIPTION
Get rid of Object.assign and use functions for references instead.

should fix #140 

released as `@4.0.0-alpha.2` for testing