### PR TITLE
For Oats packages used in the browser: Make dependency on assert explicit

### DIFF
--- a/packages/oats-axios-adapter/package.json
+++ b/packages/oats-axios-adapter/package.json
@@ -22,6 +22,7 @@
     "typescript": "^4.2.0"
   },
   "dependencies": {
+    "assert": "^2.0.0",
     "form-data": "^4.0.0"
   },
   "keywords": [

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@smartlyio/safe-navigation": "^5.0.1",
+    "assert": "^2.0.0",
     "lodash": "^4.17.20"
   },
   "keywords": [


### PR DESCRIPTION
Webpack v5 and later do not polyfill Node packages like `assert`. It is possible to manually add resolutions for those packages in the Webpack config, but it's much easier for end users if we just include those packages in our dependencies.

Packages which are used locally, like `oats`, do not need this dependency, as they are run in Node which includes `assert`.