### PR TITLE
lose dependency to node modules in packages used in browser 

### DIFF
--- a/packages/oats-axios-adapter/.eslintrc.json
+++ b/packages/oats-axios-adapter/.eslintrc.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
+    "import/no-nodejs-modules": "error",
     "import/no-cycle": "error",
     "import/no-useless-path-segments": "error",
     "import/no-self-import": "error",

--- a/packages/oats-axios-adapter/index.ts
+++ b/packages/oats-axios-adapter/index.ts
@@ -1,6 +1,6 @@
 import * as runtime from '@smartlyio/oats-runtime';
 import * as FormData from 'form-data';
-import * as assert from 'assert';
+import { fail } from './src/assert';
 import globalAxios, { AxiosInstance, AxiosResponse } from 'axios';
 import { urlSearchParamsSerializer } from './src/utils';
 
@@ -23,7 +23,7 @@ function toRequestData(data: runtime.server.RequestBody<any> | undefined) {
     });
     return form;
   }
-  assert.fail('unknown content type for axios client ' + data.contentType);
+  fail('unknown content type for axios client ' + data.contentType);
 }
 
 function axiosToJson(data: any) {
@@ -81,7 +81,7 @@ function createAxiosAdapter({
 }: AxiosAdapterOptions): runtime.client.ClientAdapter {
   return async arg => {
     if (arg.servers.length !== 1) {
-      return assert.fail('cannot decide which server to use from ' + arg.servers.join(', '));
+      return fail('cannot decide which server to use from ' + arg.servers.join(', '));
     }
     const server = arg.servers[0];
     const params = axiosToJson(arg.query);

--- a/packages/oats-axios-adapter/package.json
+++ b/packages/oats-axios-adapter/package.json
@@ -37,7 +37,6 @@
     "@jest/globals": "27.4.4",
     "@smartlyio/oats-runtime": "^4.0.3",
     "@types/form-data": "2.5.0",
-    "@types/node": "16.11.14",
     "axios": "0.24.0",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",

--- a/packages/oats-axios-adapter/src/assert.ts
+++ b/packages/oats-axios-adapter/src/assert.ts
@@ -1,0 +1,3 @@
+export function fail(msg: string): never {
+  throw new Error(msg);
+}

--- a/packages/oats-mirage-adapter/.eslintrc
+++ b/packages/oats-mirage-adapter/.eslintrc
@@ -50,6 +50,7 @@
     "jest/expect-expect": "off",
     "jest/no-standalone-expect": "off",
     "jest/valid-describe": "off",
+    "import/no-nodejs-modules":  "error",
     "import/no-cycle": "error",
     "import/no-useless-path-segments": "error",
     "import/no-self-import": "error",

--- a/packages/oats-mirage-adapter/render-docs.ts
+++ b/packages/oats-mirage-adapter/render-docs.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
+// eslint-disable-next-line import/no-nodejs-modules
 import * as fs from 'fs';
 
 const md: string = fs.readFileSync('README.template.md', 'utf8');

--- a/packages/oats-runtime/.eslintrc
+++ b/packages/oats-runtime/.eslintrc
@@ -59,6 +59,7 @@
     "jest/expect-expect": "off",
     "jest/no-standalone-expect": "off",
     "jest/valid-describe": "off",
+    "import/no-nodejs-modules": "error",
     "import/no-cycle": "error",
     "import/no-useless-path-segments": "error",
     "import/no-self-import": "error",

--- a/packages/oats-runtime/src/assert.ts
+++ b/packages/oats-runtime/src/assert.ts
@@ -1,0 +1,9 @@
+export function assert(condition: any, msg: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg);
+  }
+}
+
+export function fail(msg: string): never {
+  throw new Error(msg);
+}

--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -1,6 +1,6 @@
 import * as server from './server';
-import * as assert from 'assert';
 import safe from '@smartlyio/safe-navigation';
+import { assert } from './assert';
 
 type HasOnlyOptionalTypes<O> = Partial<O> extends O ? true : O extends void ? true : false;
 

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import { assert, fail } from './assert';
 import safe from '@smartlyio/safe-navigation';
 import * as _ from 'lodash';
 import { ValueClass } from './value-class';
@@ -102,7 +102,7 @@ export class Make<V> {
     if (this.isSuccess()) {
       return Make.ok(fn(this.success()));
     }
-    return assert.fail('neither failed or succesfull make');
+    return fail('neither failed or succesfull make');
   }
 }
 

--- a/packages/oats-runtime/src/reflection-type.ts
+++ b/packages/oats-runtime/src/reflection-type.ts
@@ -1,5 +1,5 @@
 import { Maker } from './make';
-import * as assert from 'assert';
+import { assert, fail } from './assert';
 import safe from '@smartlyio/safe-navigation';
 import * as runtime from './runtime';
 
@@ -212,7 +212,7 @@ export class Traversal<Root, Leaf> {
   ): Map<NamedTypeDefinition<unknown>, Path[]> {
     const found = this.cache.get(target);
     if (!found) {
-      return assert.fail('no path to target');
+      return fail('no path to target');
     }
     const allAncestors: Map<NamedTypeDefinition<unknown>, Path[]> = new Map();
     for (const [pathStr, parents] of found.entries()) {
@@ -229,7 +229,7 @@ export class Traversal<Root, Leaf> {
             );
           }
         } else {
-          assert.fail('nearest containing named thing is not an object: ' + ancestor.name);
+          fail('nearest containing named thing is not an object: ' + ancestor.name);
         }
       });
     }

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import { assert } from './assert';
 import safeNavigation from '@smartlyio/safe-navigation';
 import { Make, MakeOptions, Maker, ValidationError, validationErrorPrinter } from './make';
 
@@ -280,10 +280,7 @@ export function createHandlerFactory<Spec>(
         Object.keys(endpoint).forEach(method => {
           const methodHandler = (endpoint as any)[method];
           const endpointWrapper = safeNavigation(tree)[path][method].$;
-          if (!endpointWrapper) {
-            assert.fail('unknown endpoint ' + method.toUpperCase() + ' ' + path);
-            return;
-          }
+          assert(endpointWrapper, 'unknown endpoint ' + method.toUpperCase() + ' ' + path);
           adapter(
             path,
             endpointWrapper.op,

--- a/packages/oats-runtime/test/runtime.spec.ts
+++ b/packages/oats-runtime/test/runtime.spec.ts
@@ -1,6 +1,8 @@
 import * as jsc from 'jsverify';
 import * as _ from 'lodash';
+// eslint-disable-next-line import/no-nodejs-modules
 import * as assert from 'assert';
+// eslint-disable-next-line import/no-nodejs-modules
 import { promisify } from 'util';
 import { make, pmap, set, map, getAll, json, setHeaders } from '../src/runtime';
 import { TestClass } from './test-class';


### PR DESCRIPTION
prevent import nodejs modules in packages that are intended to be used in the browser. Tackles https://github.com/smartlyio/oats/pull/291