### PR TITLE
add option to avoid emitting undefined union type for index signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+# 4.1.0
+
+Provide option `emitUndefinedForIndexTypes` (default true for backwards compatibility) which can be set to 
+false to avoid generating union types with `undefined` for `additionalProperties`.
+
+Typescript can be [configured](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) to consider
+index signature accesses to have implicit undefined type so we can let the caller decide on the level of safety they want.
+
 # 4.0.0
 
 Fix cyclical imports and lose the need for `Object.assign` in the generated types.

--- a/packages/oats/src/driver.ts
+++ b/packages/oats/src/driver.ts
@@ -37,7 +37,9 @@ export interface Driver {
   openapiFilePath: string;
   generatedValueClassFile: string;
   resolve?: Resolve;
+  /** @deprecated Consider using 'resolve' instead */
   externalOpenApiImports?: readonly ImportDefinition[];
+  /** @deprecated Consider using 'resolve' instead */
   externalOpenApiSpecs?: (url: string) => string | undefined;
   header?: string;
   generatedServerFile?: string;
@@ -49,6 +51,14 @@ export interface Driver {
   };
   forceGenerateTypes?: boolean; // output the type file even if it would have been already generated
   nameMapper?: NameMapper; // mapping function to customize generated shape/value/reflect names
+  /** if true emit union type with undefined for additionalProperties. Default is *true*.
+   *  Note! Likely the default will be set to false later. Now like this to avoid
+   *  breaking typechecking for existing projects.
+   *
+   * Typescript can be {@link https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess configured } to consider
+   *  index signature accesses to have implicit undefined type so we can let the caller decide on the level of safety they want.
+   * */
+  emitUndefinedForIndexTypes?: boolean;
 }
 
 interface GenerateFileOptions {
@@ -142,6 +152,7 @@ export function generateFile(opts?: GenerateFileOptions): types.Resolve {
           externalOpenApiSpecs: options.externalOpenApiSpecs,
           externalOpenApiImports: options.externalOpenApiImports,
           emitStatusCode: options.emitStatusCode,
+          emitUndefinedForIndexTypes: options.emitUndefinedForIndexTypes,
           unsupportedFeatures: options.unsupportedFeatures,
           nameMapper: options.nameMapper
         });
@@ -174,7 +185,8 @@ export function generate(driver: Driver) {
     oas: spec,
     runtimeModule: modulePath(driver.generatedValueClassFile, driver.runtimeFilePath),
     emitStatusCode: driver.emitStatusCode || emitAllStatusCodes,
-    nameMapper: driver.nameMapper || localNameMapper
+    nameMapper: driver.nameMapper || localNameMapper,
+    emitUndefinedForIndexTypes: driver.emitUndefinedForIndexTypes ?? true
   });
   if (typeSource) {
     fs.writeFileSync(driver.generatedValueClassFile, header + typeSource);

--- a/test/no-default-emit-undefined/api.yml
+++ b/test/no-default-emit-undefined/api.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: example service
+servers:
+  - url: http://localhost:12000
+paths:
+  /hasbody:
+    post:
+      description: mandatory body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/query"
+components:
+  schemas:
+    query:
+      type: object
+      additionalProperties:
+        type: string
+

--- a/test/no-default-emit-undefined/driver.ts
+++ b/test/no-default-emit-undefined/driver.ts
@@ -1,0 +1,13 @@
+import { driver } from '@smartlyio/oats';
+import * as process from 'process';
+
+process.chdir(__dirname);
+
+driver.generate({
+  generatedValueClassFile: './tmp/server/types.generated.ts',
+  generatedServerFile: './tmp/server/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve),
+  emitUndefinedForIndexTypes: false
+});

--- a/test/no-default-emit-undefined/no-emit-undefined-index.spec.ts
+++ b/test/no-default-emit-undefined/no-emit-undefined-index.spec.ts
@@ -1,0 +1,13 @@
+import * as server from './tmp/server/types.generated';
+
+describe('undefined does not get emitted', () => {
+  it('prevents using non existing query parameter', async () => {
+    // @ts-expect-error undefined cannot be used with shape
+    const nok: server.ShapeOfQuery = { foo: undefined };
+    const ok: server.ShapeOfQuery = { foo: 'abc' };
+    expect(nok && ok).toBeTruthy();
+    // @ts-expect-error undefined cannot be used for making
+    server.typeQuery.maker({ foo: undefined });
+    server.typeQuery.maker({ foo: 'abc' }).success();
+  });
+});


### PR DESCRIPTION
ts has option to do that better now so might make sense to move to use
that instead when needed