### PR TITLE
add option to omit unknown index type for additionalProperties

### DIFF
--- a/packages/oats/src/driver.ts
+++ b/packages/oats/src/driver.ts
@@ -13,6 +13,8 @@ import {
   UnsupportedFeatureBehaviour
 } from './util';
 
+export { AdditionalPropertiesIndexSignature } from './generate-types';
+
 function modulePath(importer: string, module: string | undefined) {
   if (!module) {
     return '@smartlyio/oats-runtime';

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -4,7 +4,7 @@ import safe from '@smartlyio/safe-navigation';
 import * as _ from 'lodash';
 import * as assert from 'assert';
 import * as oautil from './util';
-import { UnsupportedFeatureBehaviour, NameKind } from './util';
+import { NameKind, UnsupportedFeatureBehaviour } from './util';
 import * as path from 'path';
 import { resolvedStatusCodes } from './status-codes';
 
@@ -51,6 +51,10 @@ export interface Options {
    *  index signature accesses to have implicit undefined type so we can let the caller decide on the level of safety they want.
    * */
   emitUndefinedForIndexTypes?: boolean;
+  /** If 'AdditionalPropertiesIndexSignature.emit' or not set emit
+   * `[key: string]: unknown`
+   * for objects with `additionalProperties: true` or no additionalProperties set */
+  unknownAdditionalPropertiesIndexSignature?: AdditionalPropertiesIndexSignature;
   nameMapper: oautil.NameMapper;
 }
 
@@ -145,6 +149,9 @@ export function run(options: Options) {
       return;
     }
     if (additional === true || additional == null) {
+      if (options.unknownAdditionalPropertiesIndexSignature === AdditionalPropertiesIndexSignature.omit) {
+        return;
+      }
       return ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
     }
     if (options.emitUndefinedForIndexTypes || options.emitUndefinedForIndexTypes == null) {
@@ -1510,4 +1517,11 @@ export function run(options: Options) {
     }
     return './' + p;
   }
+}
+
+export enum AdditionalPropertiesIndexSignature {
+  /** emit unknown typed index signature when additionalProperties: true or missing (defaults to true) */
+  emit = 'emit',
+  /** do not emit unknown typed index signature when additionalProperties: true or missing*/
+  omit = 'omit'
 }

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -149,7 +149,10 @@ export function run(options: Options) {
       return;
     }
     if (additional === true || additional == null) {
-      if (options.unknownAdditionalPropertiesIndexSignature === AdditionalPropertiesIndexSignature.omit) {
+      if (
+        options.unknownAdditionalPropertiesIndexSignature ===
+        AdditionalPropertiesIndexSignature.omit
+      ) {
         return;
       }
       return ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);

--- a/test/no-emit-unknown-index/api.yml
+++ b/test/no-emit-unknown-index/api.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: example service
+servers:
+  - url: http://localhost:12000
+paths: []
+components:
+  schemas:
+    typedAdditional:
+      type: object
+      additionalProperties:
+        type: string
+      properties:
+        foo:
+          type: string
+    explicitAdditional:
+      type: object
+      additionalProperties: true
+      properties:
+        foo:
+          type: string
+    defaultAdditional:
+      type: object
+      properties:
+        foo:
+          type: string
+

--- a/test/no-emit-unknown-index/driver.ts
+++ b/test/no-emit-unknown-index/driver.ts
@@ -1,0 +1,15 @@
+import { driver } from '@smartlyio/oats';
+import * as process from 'process';
+import { AdditionalPropertiesIndexSignature } from '../../packages/oats/src/generate-types';
+
+process.chdir(__dirname);
+
+driver.generate({
+  generatedValueClassFile: './tmp/server/types.generated.ts',
+  generatedServerFile: './tmp/server/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve),
+  emitUndefinedForIndexTypes: false,
+  unknownAdditionalPropertiesIndexSignature: AdditionalPropertiesIndexSignature.omit
+});

--- a/test/no-emit-unknown-index/driver.ts
+++ b/test/no-emit-unknown-index/driver.ts
@@ -1,6 +1,5 @@
 import { driver } from '@smartlyio/oats';
 import * as process from 'process';
-import { AdditionalPropertiesIndexSignature } from '../../packages/oats/src/generate-types';
 
 process.chdir(__dirname);
 
@@ -11,5 +10,5 @@ driver.generate({
   openapiFilePath: './api.yml',
   resolve: driver.compose(driver.generateFile(), driver.localResolve),
   emitUndefinedForIndexTypes: false,
-  unknownAdditionalPropertiesIndexSignature: AdditionalPropertiesIndexSignature.omit
+  unknownAdditionalPropertiesIndexSignature: driver.AdditionalPropertiesIndexSignature.omit
 });

--- a/test/no-emit-unknown-index/no-emit-unknown-index.spec.ts
+++ b/test/no-emit-unknown-index/no-emit-unknown-index.spec.ts
@@ -1,0 +1,12 @@
+import * as server from './tmp/server/types.generated';
+
+describe('unknown index signatures', () => {
+  it('prevents using non existing query parameter', async () => {
+    // @ts-expect-error extra prop
+    const nok: server.ShapeOfDefaultAdditional = { foo: 'a', a: 'a' };
+    // @ts-expect-error extra prop
+    const nok2: server.ShapeOfExplicitAdditional = { foo: 'a', a: 'a' };
+    const nok3: server.ShapeOfTypedAdditional = { foo: 'a', a: 'a' };
+    nok && nok2 && nok3;
+  });
+});


### PR DESCRIPTION
`additionalproperties: true` results in `[key:string]: unknown` signatures in objects. This is tedious if the additional prop is there to allow non-breaking migrations. Lets allow omitting the unknow signatures.