### PR TITLE
AETHER-2101 implement runtime redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/koa-router": "7.4.4",
     "@typescript-eslint/eslint-plugin": "5.14.0",
     "@typescript-eslint/parser": "5.14.0",
+    "axios": "0.26.1",
     "eslint": "8.10.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.25.4",

--- a/packages/oats-koa-adapter/index.ts
+++ b/packages/oats-koa-adapter/index.ts
@@ -59,7 +59,10 @@ function adapter<StateT, CustomT, RequestContext>(
         });
         ctx.body = result.value.value;
         ctx.status = result.status;
-        ctx.set('Content-Type', result.value.contentType);
+
+        if (result.value.contentType !== runtime.noContentContentType) {
+          ctx.set('content-type', result.value.contentType);
+        }
         ctx.set(result.headers);
       }
     );

--- a/packages/oats-koa-adapter/index.ts
+++ b/packages/oats-koa-adapter/index.ts
@@ -59,6 +59,7 @@ function adapter<StateT, CustomT, RequestContext>(
         });
         ctx.body = result.value.value;
         ctx.status = result.status;
+        ctx.set('Content-Type', result.value.contentType);
         ctx.set(result.headers);
       }
     );

--- a/packages/oats-runtime/.npmrc
+++ b/packages/oats-runtime/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -23,6 +23,10 @@
   },
   "dependencies": {
     "@smartlyio/safe-navigation": "^5.0.1",
+    "@types/encodeurl": "^1.0.0",
+    "@types/escape-html": "^1.0.1",
+    "encodeurl": "^1.0.2",
+    "escape-html": "^1.0.3",
     "lodash": "^4.17.20"
   },
   "keywords": [

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -23,9 +23,7 @@
   },
   "dependencies": {
     "@smartlyio/safe-navigation": "^5.0.1",
-    "@types/encodeurl": "^1.0.0",
     "@types/escape-html": "^1.0.1",
-    "encodeurl": "^1.0.2",
     "escape-html": "^1.0.3",
     "lodash": "^4.17.20"
   },

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "yarn clean:dist && rm -f ./tmp/*.ts",
     "clean:dist": "rm -rf ./dist",
-    "prebuild": "yarn clean",
+    "prebuild": "yarn clean && yarn tsc --project tsconfig.test.json --noEmit",
     "build": "yarn tsc",
     "lint": "eslint --max-warnings=0 --ext .ts src test"
   },

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@smartlyio/safe-navigation": "^5.0.1",
-    "@types/escape-html": "^1.0.1",
-    "escape-html": "^1.0.3",
+    "@types/escape-html": "1.0.1",
+    "escape-html": "1.0.3",
     "lodash": "^4.17.20"
   },
   "keywords": [

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -1,0 +1,65 @@
+import type { Response } from './server';
+import encodeUrl = require('encodeurl');
+import escapeHtml = require('escape-html');
+
+const REDIRECT_STATUSES = [300, 301, 302, 303, 305, 307, 308] as const;
+const DEFAULT_REDIRECT_STATUS = 302;
+const TEXT_HTML_CONTENT_TYPE = 'text/html';
+const TEXT_PLAIN_CONTENT_TYPE = 'text/plain';
+
+export type RedirectStatus = typeof REDIRECT_STATUSES[number];
+
+export function redirect<
+  Status extends RedirectStatus = typeof DEFAULT_REDIRECT_STATUS,
+  ContentType extends string = typeof TEXT_HTML_CONTENT_TYPE,
+  Value = string
+>(
+  url: string,
+  options: {
+    status?: Status;
+    contentType?: ContentType;
+    value?: Value;
+  } = {}
+): Response<Status, ContentType, Value, Record<string, any>> {
+  const { status = DEFAULT_REDIRECT_STATUS as Status } = options;
+  const encodedUrl = encodeUrl(url);
+
+  if (!REDIRECT_STATUSES.includes(status)) {
+    throw new Error(`Status "${status}" is not a redirect status.`);
+  }
+
+  const {
+    contentType = TEXT_HTML_CONTENT_TYPE as ContentType,
+    value = getDefaultRedirectValue({ encodedUrl, contentType }) as unknown as Value
+  } = options;
+
+  return {
+    status,
+    value: { contentType, value },
+    headers: {
+      Location: encodedUrl
+    }
+  };
+}
+
+function getDefaultRedirectValue({
+  encodedUrl,
+  contentType
+}: {
+  encodedUrl: string;
+  contentType: string;
+}) {
+  // This is what Koa responds with. Maybe it is a good practice.
+  if (isContentType({ contentType, base: TEXT_HTML_CONTENT_TYPE })) {
+    const escapedUrl = escapeHtml(encodedUrl);
+    return `Redirecting to <a href="${escapedUrl}">${escapedUrl}</a>.`;
+  }
+  if (isContentType({ contentType, base: TEXT_PLAIN_CONTENT_TYPE })) {
+    return `Redirecting to ${encodedUrl}.`;
+  }
+  return null;
+}
+
+function isContentType({ contentType, base }: { contentType: string; base: string }) {
+  return contentType === base || contentType.startsWith(base + ';');
+}

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -9,10 +9,18 @@ const TEXT_PLAIN_CONTENT_TYPE = 'text/plain';
 
 export type RedirectStatus = typeof REDIRECT_STATUSES[number];
 
+type DefaultValue<ContentType extends string> = ContentType extends
+  | typeof TEXT_HTML_CONTENT_TYPE
+  | typeof TEXT_PLAIN_CONTENT_TYPE
+  | `${typeof TEXT_HTML_CONTENT_TYPE};${string}`
+  | `${typeof TEXT_PLAIN_CONTENT_TYPE};${string}`
+  ? string
+  : null;
+
 export function redirect<
   Status extends RedirectStatus = typeof DEFAULT_REDIRECT_STATUS,
   ContentType extends string = typeof TEXT_HTML_CONTENT_TYPE,
-  Value = string
+  Value = DefaultValue<ContentType>
 >(
   url: string,
   options: {
@@ -27,7 +35,6 @@ export function redirect<
   if (!REDIRECT_STATUSES.includes(status)) {
     throw new Error(`Status "${status}" is not a redirect status.`);
   }
-
   const {
     contentType = TEXT_HTML_CONTENT_TYPE as ContentType,
     value = getDefaultRedirectValue({ encodedUrl, contentType }) as unknown as Value

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -1,5 +1,4 @@
 import type { Response } from './server';
-import encodeUrl = require('encodeurl');
 import escapeHtml = require('escape-html');
 
 const REDIRECT_STATUSES = [300, 301, 302, 303, 305, 307, 308] as const;
@@ -28,9 +27,9 @@ export function redirect<
     contentType?: ContentType;
     value?: Value;
   } = {}
-): Response<Status, ContentType, Value, Record<string, any>> {
+): Response<Status, ContentType, Value, { Location: string }> {
   const { status = DEFAULT_REDIRECT_STATUS as Status } = options;
-  const encodedUrl = encodeUrl(url);
+  const encodedUrl = encodeURI(url);
 
   if (!REDIRECT_STATUSES.includes(status)) {
     throw new Error(`Status "${status}" is not a redirect status.`);

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -55,8 +55,8 @@ function getDefaultRedirectValue({
   encodedUrl: string;
   contentType: string;
 }) {
-  // This is what Koa responds with. Maybe it is a good practice.
   if (isContentType({ contentType, base: TEXT_HTML_CONTENT_TYPE })) {
+    // In case automatic redirects are turned off, respond with a redirect link for the user to proceed.
     const escapedUrl = escapeHtml(encodedUrl);
     return `Redirecting to <a href="${escapedUrl}">${escapedUrl}</a>.`;
   }

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -16,6 +16,16 @@ type DefaultValue<ContentType extends string> = ContentType extends
   ? string
   : null;
 
+/**
+ * This hack is needed to use the provided generic types defaults rather than their inferred values.
+ * For example, this should result in error because the default status is 302:
+ * ```typescript
+ * const response: Response<308, 'text/html', string, { Location: string }> = redirect('/');
+ * ```
+ * But it will pass if type inference is not prevented.
+ */
+type PreventGenericDefaultValueOverride<T> = [T][T extends unknown ? 0 : never];
+
 export function redirect<
   Status extends RedirectStatus = typeof DEFAULT_REDIRECT_STATUS,
   ContentType extends string = typeof TEXT_HTML_CONTENT_TYPE,
@@ -27,7 +37,12 @@ export function redirect<
     contentType?: ContentType;
     value?: Value;
   } = {}
-): Response<Status, ContentType, Value, { Location: string }> {
+): Response<
+  PreventGenericDefaultValueOverride<Status>,
+  PreventGenericDefaultValueOverride<ContentType>,
+  PreventGenericDefaultValueOverride<Value>,
+  { Location: string }
+> {
   const { status = DEFAULT_REDIRECT_STATUS as Status } = options;
   const encodedUrl = encodeURI(url);
 

--- a/packages/oats-runtime/src/runtime.ts
+++ b/packages/oats-runtime/src/runtime.ts
@@ -5,6 +5,8 @@ import { fromReflection } from './make';
 import * as valueClass from './value-class';
 import * as reflection from './reflection-type';
 
+export { redirect } from './redirect';
+
 export { make, fromReflection, server, client, valueClass, reflection };
 
 export const noContentContentType = 'oatsNoContent' as const;

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -2,6 +2,8 @@ import { assert } from './assert';
 import safeNavigation from '@smartlyio/safe-navigation';
 import { Make, MakeOptions, Maker, ValidationError, validationErrorPrinter } from './make';
 
+export type { RedirectStatus } from './redirect';
+
 export interface Response<
   Status extends number,
   ContentType,

--- a/packages/oats-runtime/test/redirect.spec.ts
+++ b/packages/oats-runtime/test/redirect.spec.ts
@@ -33,10 +33,12 @@ describe('redirect()', () => {
   });
 
   it('does not override generic type default value', () => {
+    const response1: Response<302, 'text/html', string, { Location: string }> = redirect('/');
     // @ts-expect-error
-    const response: Response<308, 'text/html', string, { Location: string }> = redirect('/');
+    const response2: Response<308, 'text/html', string, { Location: string }> = redirect('/');
 
-    expect(response).toBeTruthy();
+    expect(response1).toBeTruthy();
+    expect(response2).toBeTruthy();
   });
 
   it('overrides default "text/html" content type', () => {

--- a/packages/oats-runtime/test/redirect.spec.ts
+++ b/packages/oats-runtime/test/redirect.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import type { RedirectStatus } from '../src/server';
+import type { RedirectStatus, Response } from '../src/server';
 import { redirect } from '../src/redirect';
 
 describe('redirect()', () => {
@@ -30,6 +30,13 @@ describe('redirect()', () => {
       value: { contentType: 'text/html', value: '' },
       headers: { Location: '/' }
     });
+  });
+
+  it('does not override generic type default value', () => {
+    // @ts-expect-error
+    const response: Response<308, 'text/html', string, { Location: string }> = redirect('/');
+
+    expect(response).toBeTruthy();
   });
 
   it('overrides default "text/html" content type', () => {

--- a/packages/oats-runtime/test/redirect.spec.ts
+++ b/packages/oats-runtime/test/redirect.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from '@jest/globals';
+import type { RedirectStatus } from '../src/server';
+import { redirect } from '../src/redirect';
+
+describe('redirect()', () => {
+  it('does not accept non-redirect status', () => {
+    expect(() => redirect('/', { status: 200 as RedirectStatus })).toThrow(
+      'Status "200" is not a redirect status.'
+    );
+    expect(() => redirect('/', { status: 310 as RedirectStatus })).toThrow(
+      'Status "310" is not a redirect status.'
+    );
+  });
+
+  it('returns default redirect response when no options is provided', () => {
+    const response = redirect('/');
+
+    expect(response).toEqual({
+      status: 302,
+      value: { contentType: 'text/html', value: 'Redirecting to <a href="/">/</a>.' },
+      headers: { Location: '/' }
+    });
+  });
+
+  it('overrides default status and value', () => {
+    const response = redirect('/', { status: 308, value: '' });
+
+    expect(response).toEqual({
+      status: 308,
+      value: { contentType: 'text/html', value: '' },
+      headers: { Location: '/' }
+    });
+  });
+
+  it('overrides default "text/html" content type', () => {
+    const response = redirect('/', { contentType: 'text/html; charset=utf-8' });
+
+    expect(response).toEqual({
+      status: 302,
+      value: {
+        contentType: 'text/html; charset=utf-8',
+        value: 'Redirecting to <a href="/">/</a>.'
+      },
+      headers: { Location: '/' }
+    });
+  });
+
+  it('changes the default response value when content type is not "text/html"', () => {
+    const response = redirect('/', { contentType: 'text/plain' });
+
+    expect(response).toEqual({
+      status: 302,
+      value: {
+        contentType: 'text/plain',
+        value: 'Redirecting to /.'
+      },
+      headers: { Location: '/' }
+    });
+  });
+
+  it('sets default value as null in case of non-text content tyoe', () => {
+    const response = redirect('/', { contentType: 'application/json' });
+
+    expect(response).toEqual({
+      status: 302,
+      value: { contentType: 'application/json', value: null },
+      headers: { Location: '/' }
+    });
+  });
+
+  it('encodes url in the location header', () => {
+    const response = redirect('https://www.example.com/?a= &b', {
+      contentType: 'text/plain'
+    });
+    const encodedUrl = 'https://www.example.com/?a=%20&b';
+
+    expect(response).toEqual({
+      status: 302,
+      value: {
+        contentType: 'text/plain',
+        value: `Redirecting to ${encodedUrl}.`
+      },
+      headers: { Location: encodedUrl }
+    });
+  });
+
+  it('escapes url in html response', () => {
+    const response = redirect('https://www.example.com/?a= &b');
+    const encodedUrl = 'https://www.example.com/?a=%20&b';
+    const escapedUrl = 'https://www.example.com/?a=%20&amp;b';
+
+    expect(response).toEqual({
+      status: 302,
+      value: {
+        contentType: 'text/html',
+        value: `Redirecting to <a href="${escapedUrl}">${escapedUrl}</a>.`
+      },
+      headers: { Location: encodedUrl }
+    });
+  });
+});

--- a/test/koa-adapter/api.yml
+++ b/test/koa-adapter/api.yml
@@ -3,9 +3,35 @@ info:
   title: Test spec
   version: v1
 paths:
+  /:
+    get:
+      description: Get home page
+      responses:
+        200:
+          description: Home page
+          content:
+            text/plain:
+              schema:
+                type: string
   /test:
     get:
       description: Test endpoint
       responses:
         201:
           description: Test response
+  /test-redirect:
+    get:
+      description: Redirect to root
+      responses:
+        200:
+          description: Home page
+          content:
+            text/plain:
+              schema:
+                type: string
+        302:
+          description: Redirect response
+          content:
+            text/html:
+              schema:
+                type: string

--- a/test/koa-adapter/koa-adapter.spec.ts
+++ b/test/koa-adapter/koa-adapter.spec.ts
@@ -98,8 +98,10 @@ describe('Koa adapter', () => {
   });
 
   it('sets a valid status code, when noContent is returned', async () => {
-    const item = await apiClient.test.get();
-    expect(item.status).toEqual(201);
+    const response = await apiClient.test.get();
+    expect(response.status).toEqual(201);
+    expect(response.value.contentType).toBe(runtime.noContentContentType);
+    expect(response.headers['content-type']).toBeUndefined();
   });
 
   it('hits the given middleware', async () => {
@@ -108,16 +110,18 @@ describe('Koa adapter', () => {
   });
 
   it('redirects to "/"', async () => {
-    const result = await apiClient['test-redirect'].get();
-    expect(result.status).toBe(200);
-    expect(result.value.contentType).toBe('text/plain');
-    expect(result.value.value).toBe('Welcome to Home Page!');
+    const response = await apiClient['test-redirect'].get();
+    expect(response.status).toBe(200);
+    expect(response.value.contentType).toBe('text/plain');
+    expect(response.value.value).toBe('Welcome to Home Page!');
+    expect(response.headers['content-type']).toBe('text/plain');
   });
 
   it('does not redirect to "/" if auto redirect is not enabled', async () => {
-    const result = await apiClientNoAutoRedirect['test-redirect'].get();
-    expect(result.status).toBe(302);
-    expect(result.value.contentType).toBe('text/html');
-    expect(result.value.value).toBe('Redirecting to <a href="/">/</a>.');
+    const response = await apiClientNoAutoRedirect['test-redirect'].get();
+    expect(response.status).toBe(302);
+    expect(response.value.contentType).toBe('text/html');
+    expect(response.value.value).toBe('Redirecting to <a href="/">/</a>.');
+    expect(response.headers['content-type']).toBe('text/html');
   });
 });


### PR DESCRIPTION
This implements a "runtime.redirect()" helper. It returns the same "server.Response" object, but checks for redirect status and sets Location header.