### PR TITLE
Generate enpoints as types instead of interfaces

### DIFF
--- a/packages/oats/src/generate-server.ts
+++ b/packages/oats/src/generate-server.ts
@@ -251,13 +251,12 @@ function generateClientSpec(opts: Options) {
     }, memo);
   }, client.emptyTree<ts.TypeNode>());
   return ts.createNodeArray([
-    ts.createInterfaceDeclaration(
+    ts.createTypeAliasDeclaration(
       undefined,
       [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
       'ClientSpec',
       undefined,
-      undefined,
-      generateClientTree(opts, tree)
+      ts.createTypeLiteralNode(generateClientTree(opts, tree))
     )
   ]);
 }
@@ -277,13 +276,12 @@ function generateEndpointsType(opts: Options) {
     });
   });
   return ts.createNodeArray([
-    ts.createInterfaceDeclaration(
+    ts.createTypeAliasDeclaration(
       undefined,
       [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
       'EndpointsWithContext',
       [ts.createTypeParameterDeclaration('RequestContext', undefined, undefined)],
-      undefined,
-      members
+      ts.createTypeLiteralNode(members)
     ),
     ts.createTypeAliasDeclaration(
       undefined,


### PR DESCRIPTION
Generate types as:
```ts
export type EndpointsWithContext<RequestContext> = {
    readonly "/item"?: {
        readonly "post": oar.server.Endpoint<types.Headers$Item$Post, types.Parameters$Item$Post, types.Query$Item$Post, types.RequestBody$Item$Post, types.ShapeOfResponse$Item$Post, RequestContext>;
    };
    readonly "/item/{id}"?: {
        readonly "get": oar.server.Endpoint<types.Headers$Item$Id$Get, types.Parameters$Item$Id$Get, types.Query$Item$Id$Get, types.RequestBody$Item$Id$Get, types.ShapeOfResponse$Item$Id$Get, RequestContext>;
        readonly "head": oar.server.Endpoint<types.Headers$Item$Id$Head, types.Parameters$Item$Id$Head, types.Query$Item$Id$Head, types.RequestBody$Item$Id$Head, types.ShapeOfResponse$Item$Id$Head, RequestContext>;
        readonly "delete": oar.server.Endpoint<types.Headers$Item$Id$Delete, types.Parameters$Item$Id$Delete, types.Query$Item$Id$Delete, types.RequestBody$Item$Id$Delete, types.ShapeOfResponse$Item$Id$Delete, RequestContext>;
    };
};
```

instead of:
```ts
export interface EndpointsWithContext<RequestContext> {
    readonly "/item"?: {
        readonly "post": oar.server.Endpoint<types.Headers$Item$Post, types.Parameters$Item$Post, types.Query$Item$Post, types.RequestBody$Item$Post, types.ShapeOfResponse$Item$Post, RequestContext>;
    };
    readonly "/item/{id}"?: {
        readonly "get": oar.server.Endpoint<types.Headers$Item$Id$Get, types.Parameters$Item$Id$Get, types.Query$Item$Id$Get, types.RequestBody$Item$Id$Get, types.ShapeOfResponse$Item$Id$Get, RequestContext>;
        readonly "head": oar.server.Endpoint<types.Headers$Item$Id$Head, types.Parameters$Item$Id$Head, types.Query$Item$Id$Head, types.RequestBody$Item$Id$Head, types.ShapeOfResponse$Item$Id$Head, RequestContext>;
        readonly "delete": oar.server.Endpoint<types.Headers$Item$Id$Delete, types.Parameters$Item$Id$Delete, types.Query$Item$Id$Delete, types.RequestBody$Item$Id$Delete, types.ShapeOfResponse$Item$Id$Delete, RequestContext>;
    };
};
```

A type such as `Record<string, any>` is compatible with the `type` above, but isn't compatible with the `interface`. This makes it tricky if one is trying to create a generic function that accepts any endpoint declaration object from many different openapi specs