### PR TITLE
fix: use encodeurl instead of encodeURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 Prior to that, the content type was determined automatically by Koa.
 
+# 4.3.2
+
+## Bug Fixes
+
+### `encodeURI` is replaced with `encodeurl` for redirect url encoding.
+
+`encodeURI` does double encoding of already encoded query parameters. `runtime.redirect()` will encode url with `encodeurl` now. See https://github.com/pillarjs/encodeurl.
+
 # 4.1.0
 
 Provide option `emitUndefinedForIndexTypes` (default true for backwards compatibility) which can be set to 

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "@smartlyio/safe-navigation": "^5.0.1",
+    "@types/encodeurl": "1.0.0",
     "@types/escape-html": "1.0.1",
+    "encodeurl": "1.0.2",
     "escape-html": "1.0.3",
     "lodash": "^4.17.20"
   },

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -27,6 +27,12 @@ type DefaultValue<ContentType extends string> = ContentType extends
  */
 type PreventGenericDefaultValueOverride<T> = [T][T extends unknown ? 0 : never];
 
+/**
+ * Use to perform HTTP redirect.
+ * @param url an absolute or relative URL string. Will be encoded with `encodeurl` and set as "Location" header (@see https://github.com/pillarjs/encodeurl).
+ * @param options optional `status`, `contentType`, `value` that will override the default ones. Default `status` is 302, `contentType` is "text/html".
+ * @returns redirect server response.
+ */
 export function redirect<
   Status extends RedirectStatus = typeof DEFAULT_REDIRECT_STATUS,
   ContentType extends string = typeof TEXT_HTML_CONTENT_TYPE,

--- a/packages/oats-runtime/src/redirect.ts
+++ b/packages/oats-runtime/src/redirect.ts
@@ -1,5 +1,6 @@
 import type { Response } from './server';
 import escapeHtml = require('escape-html');
+import encodeUrl = require('encodeurl');
 
 const REDIRECT_STATUSES = [300, 301, 302, 303, 305, 307, 308] as const;
 const DEFAULT_REDIRECT_STATUS = 302;
@@ -44,7 +45,7 @@ export function redirect<
   { Location: string }
 > {
   const { status = DEFAULT_REDIRECT_STATUS as Status } = options;
-  const encodedUrl = encodeURI(url);
+  const encodedUrl = encodeUrl(url);
 
   if (!REDIRECT_STATUSES.includes(status)) {
     throw new Error(`Status "${status}" is not a redirect status.`);

--- a/packages/oats-runtime/test/redirect.spec.ts
+++ b/packages/oats-runtime/test/redirect.spec.ts
@@ -78,10 +78,18 @@ describe('redirect()', () => {
   });
 
   it('encodes url in the location header', () => {
-    const response = redirect('https://www.example.com/?a= &b', {
-      contentType: 'text/plain'
-    });
-    const encodedUrl = 'https://www.example.com/?a=%20&b';
+    // Make sure it does not encode already encoded params.
+    const alreadyEncodedParam = encodeURIComponent('&');
+    const toEncode = ' \u0439';
+    const response = redirect(
+      `https://www.example.com/?param=,;=${toEncode}&alreadyEncodedParam=${alreadyEncodedParam}`,
+      {
+        contentType: 'text/plain'
+      }
+    );
+    const encodedUrl = `https://www.example.com/?param=,;=${encodeURIComponent(
+      toEncode
+    )}&alreadyEncodedParam=${alreadyEncodedParam}`;
 
     expect(response).toEqual({
       status: 302,


### PR DESCRIPTION
Turned out `encodeURI` does double encoding of already encoded params. Both koa and express are using `encodeurl` package in their redirect implementation.