### PR TITLE
Allow developer to disable logging from mirage adapter

### DIFF
--- a/packages/oats-mirage-adapter/index.ts
+++ b/packages/oats-mirage-adapter/index.ts
@@ -43,17 +43,15 @@ async function handleFormData(value: FormData) {
   return result;
 }
 
-function adapter<Registry extends mirageTypes.AnyRegistry, RequestContext>({
-  mirageServer,
-  requestContextCreator,
-  logging = true
-}: {
-  mirageServer: mirage.Server<Registry>;
-  requestContextCreator: (schema: Schema<Registry>, request: mirage.Request) => RequestContext;
-  logging: boolean;
-}): runtime.server.ServerAdapter {
+function adapter<Registry extends mirageTypes.AnyRegistry, RequestContext>(
+  mirageServer: mirage.Server<Registry>,
+  requestContextCreator: (schema: Schema<Registry>, request: mirage.Request) => RequestContext,
+  opts?: {
+    logging?: boolean;
+  }
+): runtime.server.ServerAdapter {
   // eslint-disable-next-line no-console, @typescript-eslint/no-empty-function
-  const log = logging === true ? console.log : () => {};
+  const log = opts?.logging !== false ? console.log : () => {};
 
   return (
     path: string,
@@ -126,9 +124,7 @@ export function bind<
   logging?: boolean;
 }): void {
   opts.handler(
-    adapter({
-      mirageServer: opts.server,
-      requestContextCreator: opts.requestContextCreator || (() => ({})),
+    adapter(opts.server, opts.requestContextCreator || (() => ({})), {
       logging: opts.logging ?? true
     })
   )(opts.spec);

--- a/packages/oats-mirage-adapter/index.ts
+++ b/packages/oats-mirage-adapter/index.ts
@@ -43,11 +43,15 @@ async function handleFormData(value: FormData) {
   return result;
 }
 
-function adapter<Registry extends mirageTypes.AnyRegistry, RequestContext>(
-  mirageServer: mirage.Server<Registry>,
-  requestContextCreator: (schema: Schema<Registry>, request: mirage.Request) => RequestContext,
-  logging: boolean = true
-): runtime.server.ServerAdapter {
+function adapter<Registry extends mirageTypes.AnyRegistry, RequestContext>({
+  mirageServer,
+  requestContextCreator,
+  logging = true
+}: {
+  mirageServer: mirage.Server<Registry>;
+  requestContextCreator: (schema: Schema<Registry>, request: mirage.Request) => RequestContext;
+  logging: boolean;
+}): runtime.server.ServerAdapter {
   // eslint-disable-next-line no-console, @typescript-eslint/no-empty-function
   const log = logging === true ? console.log : () => {};
 
@@ -122,6 +126,10 @@ export function bind<
   logging?: boolean;
 }): void {
   opts.handler(
-    adapter(opts.server, opts.requestContextCreator || (() => ({})), opts.logging ?? true)
+    adapter({
+      mirageServer: opts.server,
+      requestContextCreator: opts.requestContextCreator || (() => ({})),
+      logging: opts.logging ?? true
+    })
   )(opts.spec);
 }


### PR DESCRIPTION
- Adds boolean parameter `logging` to Mirage adapter.
- The parameter can be used to control logging from within adapter.