### PR TITLE
Rename properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # 4.4.0
 
-Allow mapping properties from network format specified in the openapi spec to something more expected in typescript. 
-Eg from snake_case to camelCase. This mapping is done for headers, query parameters, path parameters and bodies.
+Allow mapping properties from network format specified in the openapi spec to something more expected in typescript. Eg
+from snake_case to camelCase. The mapping is done using `propertyNameMapper` function passed to the driver configuration
+when generating code.
 
-NOTE: due to the mapping we cannot anymore lowercase request headers on the client side. This has been prevented before by the
+NOTE: the mapping is not done for `additionalProperties` property names as those often contain maps and mapping map keys
+seemed unwise and hard to do.
+
+## Silently breaking change 
+
+Due to the mapping we cannot anymore lowercase request headers on the client side. This has been prevented before by the
 type system but if somebody has subverted the type system to allow upper cased headers you will have a bad time as 
 the uppercased headers will be dropped now. This only affects the client side usage of oats. Please check that you have well typed
 request headers on client side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ when generating code.
 NOTE: the mapping is not done for `additionalProperties` property names as those often contain maps and mapping map keys
 seemed unwise and hard to do.
 
+NOTE: unknown types such as property values for `additionalProperties: true` properties are not mapped as we do not know
+the schemas for those values.
+
 ## Silently breaking change 
 
 Due to the mapping we cannot anymore lowercase request headers on the client side. This has been prevented before by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.4.0
+# 5.0.0
 
 Allow mapping properties from network format specified in the openapi spec to something more expected in typescript. Eg
 from snake_case to camelCase. The mapping is done using `propertyNameMapper` function passed to the driver configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 4.4.0
+
+Allow mapping properties from network format specified in the openapi spec to something more expected in typescript. 
+Eg from snake_case to camelCase. This mapping is done for headers, query parameters, path parameters and bodies.
+
+NOTE: due to the mapping we cannot anymore lowercase request headers on the client side. This has been prevented before by the
+type system but if somebody has subverted the type system to allow upper cased headers you will have a bad time as 
+the uppercased headers will be dropped now. This only affects the client side usage of oats. Please check that you have well typed
+request headers on client side.
+
 # 4.3.2
 
 ## Bug Fixes

--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -184,7 +184,8 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
     handler.body,
     handler.response,
     ctx =>
-      adapter({ ...ctx, path: fillInPathParams(params, handler.path), servers: handler.servers })
+      adapter({ ...ctx, path: fillInPathParams(params, handler.path), servers: handler.servers }),
+    { mode: 'client' }
   );
   return (ctx: ClientArg<any, any, any>) =>
     call({

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -473,6 +473,10 @@ export function makeObject<
       }
       result[index] = propResult.success();
     }
+    const oldType = getType(value);
+    if (oldType) {
+      withType(result, oldType);
+    }
     return Make.ok(withType(result, type ? [type] : []));
   };
 }

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -456,6 +456,11 @@ export function getType(value: Record<string, any>): Type | undefined {
   if (!value || typeof value !== 'object') {
     return;
   }
+  if (value instanceof ValueClass) {
+    // a bit of leap here to trust that all ValueClasses have generated `reflection`
+    // @ts-ignore
+    return value.constructor.reflection().definition;
+  }
   // @ts-ignore
   return value[reflection] || undefined;
 }

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -395,6 +395,9 @@ function getInputPropName(args: {
   if (!args.opts?.convertFromNetwork) {
     return args.index;
   }
+  // we need to look at the types already used for making the value to detect cases
+  // where the property has already been mapped and we should use the ts side
+  // property name
   const types = getType(args.value) ?? [];
   const networkProp = args.fromNetwork?.[args.index] ?? args.index;
   for (const type of types) {
@@ -467,6 +470,10 @@ export function makeObject<
         }
         return error('unexpected property').errorPath(index);
       }
+      // If the input value A has been made already with network prop name mapping
+      // this runs the property value through the current additionalProps maker to validate it
+      // nb. the property key *has* already been mapped when making A and we just use it here
+      // this works unless we start mapping additionalProp property names.
       const propResult: Make<any> = additionalProp(value[index], opts);
       if (propResult.isError()) {
         return propResult.errorPath(index);

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -127,7 +127,6 @@ export interface MakeOptions {
   convertFromNetwork?: boolean;
 }
 
-/** a maker with optional reflection type from which it was constructed */
 export type Maker<Shape, V> = (value: Shape, opts?: MakeOptions) => Make<V>;
 
 function getErrorWithValueMsg<T>(msg: string, value: T): Make<T> {

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -648,8 +648,11 @@ function networkMapFromDiscriminatedType(prop: string, type: Type): string | und
       return networkMapFromDiscriminatedType(prop, type.options[0]);
     case 'union':
       return networkMapFromDiscriminatedType(prop, type.options[0]);
+    default:
+      throw new Error(
+        `Non object like type when looking for discriminator network mapping for ${prop}. This is likely a bug in oats`
+      );
   }
-  return;
 }
 
 function fromUnionReflection(types: Type[]): Maker<any, any> {

--- a/packages/oats-runtime/src/reflection-type.ts
+++ b/packages/oats-runtime/src/reflection-type.ts
@@ -96,6 +96,7 @@ export interface NamedType {
 export interface PropType {
   required: boolean;
   value: Type;
+  networkName?: string;
 }
 
 export interface Props {

--- a/packages/oats-runtime/src/runtime.ts
+++ b/packages/oats-runtime/src/runtime.ts
@@ -1,7 +1,7 @@
 import * as server from './server';
 import * as client from './client';
 import * as make from './make';
-import { fromReflection } from './make';
+import { fromReflection, getType } from './make';
 import * as valueClass from './value-class';
 import * as reflection from './reflection-type';
 
@@ -274,4 +274,29 @@ function pmapComposite<A, T>(
     return pmapObject(value, predicate, map, traversalPath);
   }
   return value;
+}
+
+export function serialize(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map(v => serialize(v));
+  }
+  const type = getType(value);
+  if (!type) {
+    return value;
+  }
+  switch (type.type) {
+    case 'object':
+      return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
+        const prop = type.properties[key];
+        const serialized = serialize(value[key]);
+        if (prop && prop.networkName) {
+          memo[prop.networkName] = serialized;
+        } else {
+          memo[key] = serialized;
+        }
+        return memo;
+      }, {});
+    default:
+      return value;
+  }
 }

--- a/packages/oats-runtime/src/runtime.ts
+++ b/packages/oats-runtime/src/runtime.ts
@@ -1,7 +1,7 @@
 import * as server from './server';
 import * as client from './client';
 import * as make from './make';
-import { fromReflection, getType } from './make';
+import { fromReflection } from './make';
 import * as valueClass from './value-class';
 import * as reflection from './reflection-type';
 
@@ -276,27 +276,3 @@ function pmapComposite<A, T>(
   return value;
 }
 
-export function serialize(value: any): any {
-  if (Array.isArray(value)) {
-    return value.map(v => serialize(v));
-  }
-  const type = getType(value);
-  if (!type) {
-    return value;
-  }
-  switch (type.type) {
-    case 'object':
-      return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
-        const prop = type.properties[key];
-        const serialized = serialize(value[key]);
-        if (prop && prop.networkName) {
-          memo[prop.networkName] = serialized;
-        } else {
-          memo[key] = serialized;
-        }
-        return memo;
-      }, {});
-    default:
-      return value;
-  }
-}

--- a/packages/oats-runtime/src/runtime.ts
+++ b/packages/oats-runtime/src/runtime.ts
@@ -275,4 +275,3 @@ function pmapComposite<A, T>(
   }
   return value;
 }
-

--- a/packages/oats-runtime/src/serialize.ts
+++ b/packages/oats-runtime/src/serialize.ts
@@ -13,11 +13,11 @@ export function serialize(value: any): any {
       case 'object':
         return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
           const prop = type.properties[key];
-          const serialized = serialize(value[key]);
-          if (prop && prop.networkName) {
-            memo[prop.networkName] = serialized;
-          } else {
-            memo[key] = serialized;
+          const networkProp = prop && prop.networkName ? prop.networkName : key;
+          // serializing the same value multiple times is ok but unnecessary so long
+          // as the mappings in different objects match. If that is not the case we are screwed.
+          if (memo[networkProp] === undefined) {
+            memo[networkProp] = serialize(value[key]);
           }
           return memo;
         }, {});

--- a/packages/oats-runtime/src/serialize.ts
+++ b/packages/oats-runtime/src/serialize.ts
@@ -1,26 +1,28 @@
-import { getType } from './make';
+import { getType } from './type-tag';
 
 export function serialize(value: any): any {
   if (Array.isArray(value)) {
     return value.map(v => serialize(v));
   }
-  const type = getType(value);
-  if (!type) {
+  const types = getType(value);
+  if (!types) {
     return value;
   }
-  switch (type.type) {
-    case 'object':
-      return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
-        const prop = type.properties[key];
-        const serialized = serialize(value[key]);
-        if (prop && prop.networkName) {
-          memo[prop.networkName] = serialized;
-        } else {
-          memo[key] = serialized;
-        }
-        return memo;
-      }, {});
-    default:
-      return value;
-  }
+  return types.reduce((value, type) => {
+    switch (type.type) {
+      case 'object':
+        return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
+          const prop = type.properties[key];
+          const serialized = serialize(value[key]);
+          if (prop && prop.networkName) {
+            memo[prop.networkName] = serialized;
+          } else {
+            memo[key] = serialized;
+          }
+          return memo;
+        }, {});
+      default:
+        return value;
+    }
+  }, value);
 }

--- a/packages/oats-runtime/src/serialize.ts
+++ b/packages/oats-runtime/src/serialize.ts
@@ -11,10 +11,14 @@ export function serialize(value: any): any {
   if (!types) {
     return value;
   }
+  let hasAdditionalProps = false;
   // get mapping from all types ts property names to network names
   const jointMap = types
     .flatMap(type => (type.type === 'object' ? [type] : []))
     .reduce<Map<string, string>>((memo, type) => {
+      if (type.additionalProperties !== false) {
+        hasAdditionalProps = true;
+      }
       for (const key in type.properties) {
         const mapped = type.properties[key].networkName;
         if (mapped != null) {
@@ -24,7 +28,7 @@ export function serialize(value: any): any {
       return memo;
     }, new Map());
   // in case there are no network mapping done we can return immediately to avoid wasting a loop
-  if (jointMap.size === 0) {
+  if (jointMap.size === 0 && !hasAdditionalProps) {
     return value;
   }
   // map value using jointMap

--- a/packages/oats-runtime/src/serialize.ts
+++ b/packages/oats-runtime/src/serialize.ts
@@ -1,0 +1,26 @@
+import { getType } from './make';
+
+export function serialize(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map(v => serialize(v));
+  }
+  const type = getType(value);
+  if (!type) {
+    return value;
+  }
+  switch (type.type) {
+    case 'object':
+      return Object.keys(value).reduce<Record<string, any>>((memo, key) => {
+        const prop = type.properties[key];
+        const serialized = serialize(value[key]);
+        if (prop && prop.networkName) {
+          memo[prop.networkName] = serialized;
+        } else {
+          memo[key] = serialized;
+        }
+        return memo;
+      }, {});
+    default:
+      return value;
+  }
+}

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -149,6 +149,9 @@ function serializeWhenClient(mode: Mode, value: any) {
 }
 
 function getOutBody<Body extends RequestBody<any>>(mode: Mode, value: Body): Body {
+  if (!value) {
+    return value;
+  }
   return { contentType: value.contentType, value: serializeWhenClient(mode, value.value) } as Body;
 }
 
@@ -210,12 +213,13 @@ export function safe<
     const responseValue = response(result, { convertFromNetwork: mode === 'client' }).success(
       throwResponseValidationError.bind(null, `body ${ctx.path}`, result.value.value)
     );
-    if (mode === 'client') {
+    if (mode === 'client' || !responseValue) {
       return responseValue;
     }
     // the response must be serialized for transferring from server to client
     return {
       ...responseValue,
+      headers: serialize(responseValue.headers),
       value: {
         ...responseValue.value,
         value: serialize(responseValue.value.value)

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -1,6 +1,7 @@
 import { assert } from './assert';
 import safeNavigation from '@smartlyio/safe-navigation';
 import { Make, MakeOptions, Maker, ValidationError, validationErrorPrinter } from './make';
+import { serialize } from './serialize';
 
 export type { RedirectStatus } from './redirect';
 
@@ -128,15 +129,27 @@ function voidify(value: object | undefined | null) {
   return null;
 }
 
-function cleanHeaders<H>(maker: Maker<any, H>, headers: object) {
+function cleanHeaders<H>(mode: Mode, maker: Maker<any, H>, headers: object) {
   const normalized = voidify(lowercaseObject(headers));
   const acceptsNull = maker(null);
   if (acceptsNull.isSuccess()) {
     return acceptsNull.success();
   }
   return maker(normalized, {
-    unknownField: 'drop'
+    unknownField: 'drop',
+    convertFromNetwork: mode === 'server'
   }).success(throwRequestValidationError.bind(null, 'headers'));
+}
+
+function serializeWhenClient(mode: Mode, value: any) {
+  if (mode === 'client') {
+    return serialize(value);
+  }
+  return value;
+}
+
+function getOutBody<Body extends RequestBody<any>>(mode: Mode, value: Body): Body {
+  return { contentType: value.contentType, value: serializeWhenClient(mode, value.value) } as Body;
 }
 
 export function safe<
@@ -153,7 +166,7 @@ export function safe<
   body: Maker<any, Body>,
   response: Maker<any, R>,
   endpoint: Endpoint<H, P, Q, Body, R, RC>,
-  { validationOptions = {} }: HandlerOptions = {}
+  { validationOptions = {}, mode }: HandlerOptions & InternalHandlerOptions = { mode: 'client' }
 ): Endpoint<
   Headers,
   Params,
@@ -163,24 +176,51 @@ export function safe<
   RequestContext
 > {
   return async ctx => {
+    // note: data coming to client adapter needs to be serialized and data coming from the adapter needs conversion from network
+    // note: data coming to server adapter needs to be deserialized and data coming from the adapter needs serialization
+    // this is all very clear.
+    const internalMakeOptions = { convertFromNetwork: mode === 'server' };
     const result = await endpoint({
       path: ctx.path,
       method: ctx.method,
       servers: ctx.servers,
       op: ctx.op,
-      headers: cleanHeaders(headers, ctx.headers),
-      params: params(voidify(ctx.params), validationOptions.params).success(
-        throwRequestValidationError.bind(null, 'params')
+      headers: serializeWhenClient(mode, cleanHeaders(mode, headers, ctx.headers)),
+      params: serializeWhenClient(
+        mode,
+        params(voidify(ctx.params), {
+          ...validationOptions.params,
+          ...internalMakeOptions
+        }).success(throwRequestValidationError.bind(null, 'params'))
       ),
-      query: query(ctx.query || {}, validationOptions.query).success(
-        throwRequestValidationError.bind(null, 'query')
+      query: serializeWhenClient(
+        mode,
+        query(ctx.query || {}, { ...validationOptions.query, ...internalMakeOptions }).success(
+          throwRequestValidationError.bind(null, 'query')
+        )
       ),
-      body: body(voidify(ctx.body)).success(throwRequestValidationError.bind(null, 'body')),
+      body: getOutBody<Body>(
+        mode,
+        body(voidify(ctx.body), internalMakeOptions).success(
+          throwRequestValidationError.bind(null, 'body')
+        )
+      ),
       requestContext: ctx.requestContext as any
     });
-    return response(result).success(
+    const responseValue = response(result, { convertFromNetwork: mode === 'client' }).success(
       throwResponseValidationError.bind(null, `body ${ctx.path}`, result.value.value)
     );
+    if (mode === 'client') {
+      return responseValue;
+    }
+    // the response must be serialized for transferring from server to client
+    return {
+      ...responseValue,
+      value: {
+        ...responseValue.value,
+        value: serialize(responseValue.value.value)
+      }
+    };
   };
 }
 
@@ -202,7 +242,7 @@ interface CheckingTree {
     [method: string]: {
       safeHandler: (
         e: Endpoint<any, any, any, any, any, any>,
-        opts?: HandlerOptions
+        opts?: HandlerOptions & InternalHandlerOptions
       ) => SafeEndpoint;
       op: string;
       servers: string[];
@@ -228,7 +268,10 @@ function createTree(handlers: Handler[]): CheckingTree {
       memo[element.path] = {};
     }
     memo[element.path][element.method] = {
-      safeHandler: (e: Endpoint<any, any, any, any, any, any>, opts?: HandlerOptions) =>
+      safeHandler: (
+        e: Endpoint<any, any, any, any, any, any>,
+        opts?: HandlerOptions & InternalHandlerOptions
+      ) =>
         safe(
           element.headers,
           element.params,
@@ -260,6 +303,15 @@ export type ServerAdapter = (
   servers: string[]
 ) => void;
 
+type Mode = 'client' | 'server';
+export interface InternalHandlerOptions {
+  /** whether we are calling this on client side or in server side.
+   * This may have effect on eg network <-> ts property mapping.
+   * This value is set automatically by oats.
+   * */
+  mode: Mode;
+}
+
 export interface HandlerOptions {
   /**
    * Options for request schema validation.
@@ -287,7 +339,7 @@ export function createHandlerFactory<Spec>(
             path,
             endpointWrapper.op,
             assertMethod(method),
-            endpointWrapper.safeHandler(methodHandler, opts),
+            endpointWrapper.safeHandler(methodHandler, { ...opts, mode: 'server' }),
             endpointWrapper.servers
           );
         });

--- a/packages/oats-runtime/src/type-tag.ts
+++ b/packages/oats-runtime/src/type-tag.ts
@@ -1,0 +1,63 @@
+import { Type } from './reflection-type';
+import { ValueClass } from './value-class';
+
+export function withType<A>(to: A, type: Type[]): A {
+  if (type.length === 0) {
+    return to;
+  }
+  // todo: is it possible to confuse typing by re-use of valueclassed values
+  //  eg. with value 'v: SomeValueClass' passing it to multiple makers
+  // -> no? the re-use happens only if the valueclass instance matches so it
+  // will not mutate the tagged reflection types
+  const previous = getTypeSet(to);
+  if (previous) {
+    type.forEach(type => previous.add(type));
+    return to;
+  }
+  const newType = new Set(type);
+  // tag each constructed object with a hidden type property
+  Object.defineProperty(to, reflection, {
+    enumerable: false,
+    value: newType
+  });
+  return to;
+}
+
+export function getTypeSet(value: Record<string, any>): Set<Type> | undefined {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  // NOTE: prefer using the added reflection type instead of the contstructor type
+  // the added reflection type will have types from eg allOf
+  // @ts-ignore
+  const t: Set<Type> = value[reflection];
+  if (t && t.size > 0) {
+    return t;
+  }
+  if (value instanceof ValueClass) {
+    // a bit of leap here to trust that all ValueClasses have generated `reflection`
+    // @ts-ignore
+    const classType = new Set([value.constructor.reflection().definition]);
+    // tag each constructed object with a hidden type property
+    // this ensures that ValueClasses have a mutable reflection type property
+    Object.defineProperty(value, reflection, {
+      enumerable: false,
+      value: classType
+    });
+    return classType;
+  }
+  return;
+}
+
+/**  Get reflection type from a  made value.
+ * Note that only directly made object values or ValueClasses can be used
+ * */
+export function getType(value: Record<string, any>): Type[] | undefined {
+  const t = getTypeSet(value);
+  if (t) {
+    return [...t];
+  }
+}
+
+const reflection = Symbol();

--- a/packages/oats-runtime/src/type-tag.ts
+++ b/packages/oats-runtime/src/type-tag.ts
@@ -50,7 +50,7 @@ export function getTypeSet(value: Record<string, any>): Set<Type> | undefined {
   return;
 }
 
-/**  Get reflection type from a  made value.
+/**  Get reflection type from a  made value for serialization.
  * Note that only directly made object values or ValueClasses can be used
  * */
 export function getType(value: Record<string, any>): Type[] | undefined {

--- a/packages/oats-runtime/src/type-tag.ts
+++ b/packages/oats-runtime/src/type-tag.ts
@@ -60,4 +60,4 @@ export function getType(value: Record<string, any>): Type[] | undefined {
   }
 }
 
-const reflection = Symbol();
+const reflection = Symbol('reflection');

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -2,7 +2,7 @@ import * as make from '../src/make';
 import * as jsc from 'jsverify';
 import { TestClass } from './test-class';
 import { Type } from '../src/reflection-type';
-import { serialize } from '../src/runtime';
+import { serialize } from '../src/serialize';
 
 describe('union differentation', () => {
   it('handles cases where union children are missing the tag', () => {

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -558,6 +558,51 @@ describe('object', () => {
     });
   });
 
+  describe('property mapping', () => {
+    it('map properties from network to ts side', () => {
+      const fun = make.fromReflection({
+        type: 'object',
+        additionalProperties: false,
+        properties: { ts: { value: { type: 'number' }, required: true, networkName: 'network' } }
+      });
+      expect(fun({ network: 1 }, { convertFromNetwork: true }).success()).toEqual({ ts: 1 });
+    });
+
+    it('does not map properties without the flag', () => {
+      const fun = make.fromReflection({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ts: { value: { type: 'number' }, required: true, networkName: 'network' }
+        }
+      });
+      expect(fun({ network: 1 }, {}).errors[0]).toEqual(expect.objectContaining({ path: ['ts'] }));
+    });
+
+    it('does not map additionalProperties', () => {
+      const fun = make.fromReflection({
+        type: 'object',
+        additionalProperties: true,
+        properties: { ts: { value: { type: 'number' }, required: true, networkName: 'network' } }
+      });
+      expect(fun({ network: 1, foo: 2 }, { convertFromNetwork: true }).success()).toEqual({
+        ts: 1,
+        foo: 2
+      });
+    });
+
+    it('does not overwrite with additionalProps', () => {
+      const fun = make.fromReflection({
+        type: 'object',
+        additionalProperties: true,
+        properties: { ts: { value: { type: 'number' }, required: true, networkName: 'network' } }
+      });
+      expect(fun({ network: 1, ts: 2 }, { convertFromNetwork: true }).success()).toEqual({
+        ts: 1
+      });
+    });
+  });
+
   it('drops unknown properties if told to', () => {
     const fun = make.fromReflection({
       type: 'object',

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -588,6 +588,11 @@ describe('object', () => {
       const fun = make.fromReflection(type);
       expect(make.getType(fun({ a: 1 }).success())).toEqual(type);
     });
+
+    it('returns the type for value class', () => {
+      const value = TestClass.make({ a: [], b: 'a' }).success();
+      expect(make.getType(value)).toEqual(TestClass.reflection().definition);
+    });
   });
 
   describe('property mapping', () => {

--- a/packages/oats-runtime/test/test-class-with-additional-props.ts
+++ b/packages/oats-runtime/test/test-class-with-additional-props.ts
@@ -7,7 +7,7 @@ export type ShapeOfTestClass = ShapeOf<TestClass>;
 
 const type: ObjectType = {
   type: 'object',
-  additionalProperties: false,
+  additionalProperties: true,
   properties: {
     a: { value: { type: 'array', items: { type: 'string' } }, required: true, networkName: 'netB' },
     b: { value: { type: 'string' }, required: true, networkName: 'netB' }
@@ -25,6 +25,7 @@ export class TestClass extends ValueClass {
   }
   public b!: string;
   public a!: ReadonlyArray<string>;
+  [key: string]: unknown;
   constructor(v: ShapeOfTestClass) {
     super();
     const value = named.maker(v).success();

--- a/packages/oats-runtime/test/test-class.ts
+++ b/packages/oats-runtime/test/test-class.ts
@@ -12,7 +12,7 @@ const type: ObjectType = {
     a: { value: { type: 'array', items: { type: 'string' } }, required: true, networkName: 'netB' },
     b: { value: { type: 'string' }, required: true, networkName: 'netB' }
   }
-}
+};
 const named: NamedTypeDefinition<any> = {
   name: 'TestClass',
   maker: fromReflection(type),

--- a/packages/oats/src/driver.ts
+++ b/packages/oats/src/driver.ts
@@ -52,6 +52,11 @@ export interface Driver {
     security?: UnsupportedFeatureBehaviour;
   };
   forceGenerateTypes?: boolean; // output the type file even if it would have been already generated
+  /** property name mapper for object properties
+   *  ex. to map 'snake_case' property in network format to property 'camelCase' usable in ts code provide mapper
+   *  > propertyNameMapper: (p) => p === 'snake_case ? 'camelCase' : p
+   * */
+  propertyNameMapper?: (openapiPropertyName: string) => string;
   nameMapper?: NameMapper; // mapping function to customize generated shape/value/reflect names
   /** if true emit union type with undefined for additionalProperties. Default is *true*.
    *  Note! Likely the default will be set to false later. Now like this to avoid
@@ -164,7 +169,8 @@ export function generateFile(opts?: GenerateFileOptions): types.Resolve {
           unknownAdditionalPropertiesIndexSignature:
             options.unknownAdditionalPropertiesIndexSignature,
           unsupportedFeatures: options.unsupportedFeatures,
-          nameMapper: options.nameMapper
+          nameMapper: options.nameMapper,
+          propertyNameMapper: options.propertyNameMapper
         });
       }
     };
@@ -196,6 +202,7 @@ export function generate(driver: Driver) {
     runtimeModule: modulePath(driver.generatedValueClassFile, driver.runtimeFilePath),
     emitStatusCode: driver.emitStatusCode || emitAllStatusCodes,
     nameMapper: driver.nameMapper || localNameMapper,
+    propertyNameMapper: driver.propertyNameMapper,
     emitUndefinedForIndexTypes: driver.emitUndefinedForIndexTypes ?? true,
     unknownAdditionalPropertiesIndexSignature:
       driver.unknownAdditionalPropertiesIndexSignature ?? AdditionalPropertiesIndexSignature.emit

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -1072,7 +1072,11 @@ export function run(options: Options) {
           ts.createObjectLiteral(
             Object.keys(schema.properties || {}).map((propertyName: string) => {
               return ts.createPropertyAssignment(
-                ts.createStringLiteral(options.propertyNameMapper ? options.propertyNameMapper(propertyName) : propertyName),
+                ts.createStringLiteral(
+                  options.propertyNameMapper
+                    ? options.propertyNameMapper(propertyName)
+                    : propertyName
+                ),
                 ts.createObjectLiteral(
                   [
                     ts.createPropertyAssignment(
@@ -1081,7 +1085,14 @@ export function run(options: Options) {
                         ? ts.createTrue()
                         : ts.createFalse()
                     ),
-                    ...(options.propertyNameMapper ? [ts.createPropertyAssignment('networkName', ts.createStringLiteral(propertyName))] : []),
+                    ...(options.propertyNameMapper
+                      ? [
+                          ts.createPropertyAssignment(
+                            'networkName',
+                            ts.createStringLiteral(propertyName)
+                          )
+                        ]
+                      : []),
                     ts.createPropertyAssignment(
                       'value',
                       generateReflectionType((schema.properties as any)[propertyName])

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -647,34 +647,13 @@ export function run(options: Options) {
         ts.createExpressionStatement(ts.createCall(ts.createIdentifier('super'), [], [])),
         ts.createExpressionStatement(
           ts.createCall(
-            ts.createPropertyAccess(ts.createIdentifier('Object'), 'assign'),
+            ts.createPropertyAccess(ts.factory.createIdentifier('oar'), 'instanceAssign'),
             [],
             [
               ts.createThis(),
-              ts.createConditional(
-                ts.createBinary(
-                  ts.createIdentifier('opts'),
-                  ts.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
-                  ts.createBinary(
-                    ts.createStringLiteral('unSafeSet'),
-                    ts.createToken(ts.SyntaxKind.InKeyword),
-                    ts.createIdentifier('opts')
-                  )
-                ),
-                ts.createIdentifier('value'),
-                ts.createCall(
-                  ts.createPropertyAccess(
-                    ts.createCall(
-                      ts.createIdentifier('build' + options.nameMapper(key, 'value')),
-                      undefined,
-                      [ts.createIdentifier('value'), ts.createIdentifier('opts')]
-                    ),
-                    ts.createIdentifier('success')
-                  ),
-                  undefined,
-                  []
-                )
-              )
+              ts.createIdentifier('value'),
+              ts.createIdentifier('opts'),
+              ts.createIdentifier('build' + options.nameMapper(key, 'value'))
             ]
           )
         )

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -224,7 +224,7 @@ export function run(options: Options) {
       oautil.errorTag(`property '${key}'`, () =>
         ts.createPropertySignature(
           readonly,
-          quotedProp(key),
+          quotedProp(options.propertyNameMapper ? options.propertyNameMapper(key) : key),
           required && required.indexOf(key) >= 0
             ? undefined
             : ts.createToken(ts.SyntaxKind.QuestionToken),

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -42,6 +42,62 @@ paths:
                 $ref: "#/components/schemas/Item"
 components:
   schemas:
+    ArraySchema:
+      type: array
+      items:
+        $ref: '#/components/schemas/Item'
+    NonDiscriminatedOneOf:
+      oneOf:
+        - type: object
+          required:
+            - first_value
+          properties:
+            first_value:
+              type: string
+        - type: object
+          required:
+            - other_value
+          properties:
+            other_value:
+              type: string
+    MixedDiscrimination:
+      oneOf:
+        - $ref: "#/components/schemas/AdditionalpPropOne"
+        - $ref: "#/components/schemas/AdditionalpPropTwo"
+        - type: object
+          properties:
+            extra_value:
+              type: string
+    Discriminated:
+      description: |
+        oneOf with discriminators need mapping of the discriminator key
+      oneOf:
+        - $ref: "#/components/schemas/AdditionalpPropOne"
+        - $ref: "#/components/schemas/AdditionalpPropTwo"
+    AdditionalpPropTwo:
+      type: object
+      required:
+        - prop_tag
+      properties:
+        prop_tag:
+          type: string
+          enum:
+            - two
+    AdditionalpPropOne:
+      type: object
+      required:
+        - prop_tag
+      properties:
+        prop_tag:
+          type: string
+          enum:
+            - one
+    AdditionalPropSchema:
+      type: object
+      additionalProperties:
+        oneOf:
+          - $ref: "#/components/schemas/AdditionalpPropOne"
+          - $ref: "#/components/schemas/AdditionalpPropTwo"
     NestedNamed:
       type: object
       properties:

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -5,11 +5,32 @@ info:
 servers:
   - url: http://localhost:12000
 paths:
-  /item:
-    get:
+  /item/{some_item}:
+    post:
+      parameters:
+        - in: header
+          name: header_item
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: some_item
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Item"
       responses:
         '200':
           description: item found
+          headers:
+            reply_header:
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -23,4 +44,9 @@ components:
       properties:
         some_property:
           type: string
+        extra_prop:
+          type: object
+          properties:
+            extra_nested_object_prop:
+              type: string
 

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -8,6 +8,11 @@ paths:
   /item/{some_item}:
     post:
       parameters:
+        - in: query
+          name: some_query_item
+          required: true
+          schema:
+            type: string
         - in: header
           name: header_item
           required: true

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -64,6 +64,7 @@ components:
       oneOf:
         - $ref: "#/components/schemas/AdditionalpPropOne"
         - $ref: "#/components/schemas/AdditionalpPropTwo"
+        - type: string
         - type: object
           properties:
             extra_value:

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -42,11 +42,33 @@ paths:
                 $ref: "#/components/schemas/Item"
 components:
   schemas:
+    AllOfSchema:
+      allOf:
+        - $ref: "#/components/schemas/Item"
+        - allOf:
+          - $ref: "#/components/schemas/ThirdItem"
+          - $ref: "#/components/schemas/SecondItem"
+    ThirdItem:
+      type: object
+      properties:
+        overlapping_property:
+          type: string
+        extra_second_property:
+          type: string
+        extra_third_property:
+          type: string
+    SecondItem:
+      type: object
+      properties:
+        extra_second_property:
+          type: string
     Item:
       type: object
       required:
         - some_property
       properties:
+        overlapping_property:
+          type: string
         some_property:
           type: string
         extra_prop:

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -68,7 +68,9 @@ components:
         - some_property
       properties:
         overlapping_property:
-          type: string
+          oneOf:
+            - type: string
+            - type: number
         some_property:
           type: string
         extra_prop:

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -42,6 +42,31 @@ paths:
                 $ref: "#/components/schemas/Item"
 components:
   schemas:
+    NestedNamed:
+      type: object
+      properties:
+        nested_named_prop:
+          type: string
+    SchemaWithNestedObjects:
+      allOf:
+        - type: object
+          properties:
+            prop:
+              type: object
+              properties:
+                first_nested:
+                  type: string
+        - type: object
+          properties:
+            prop:
+              type: object
+              properties:
+                second_nested:
+                  type: string
+        - type: object
+          properties:
+            prop:
+              $ref: "#/components/schemas/NestedNamed"
     AllOfSchema:
       allOf:
         - $ref: "#/components/schemas/Item"

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -68,6 +68,19 @@ components:
           properties:
             extra_value:
               type: string
+    AllOfWithDiscrimination:
+      description: |
+        test that we consider the mapped discriminator
+      allOf:
+        - type: object
+          properties:
+            prop_tag:
+              type: string
+        - $ref: '#/components/schemas/Discriminated'
+        - type: object
+          properties:
+            prop_tag:
+              type: string
     Discriminated:
       description: |
         oneOf with discriminators need mapping of the discriminator key

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: example service
+servers:
+  - url: http://localhost:12000
+paths:
+  /item:
+    get:
+      responses:
+        '200':
+          description: item found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - some_property
+      properties:
+        some_property:
+          type: string
+

--- a/test/property-name-mapping/driver.ts
+++ b/test/property-name-mapping/driver.ts
@@ -1,0 +1,26 @@
+import { driver } from '@smartlyio/oats';
+import * as process from 'process';
+
+process.chdir(__dirname);
+function camelCaser(openapiProp: string): string {
+  const [head, ...tail] = openapiProp.split('_');
+  return [...head, ...tail.map(t => `${t[0].toUpperCase()}${t.slice(1)}`)].join('');
+}
+
+driver.generate({
+  generatedValueClassFile: './tmp/client/types.generated.ts',
+  generatedClientFile: './tmp/client/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  propertyNameMapper: camelCaser,
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});
+
+driver.generate({
+  generatedValueClassFile: './tmp/server/types.generated.ts',
+  generatedServerFile: './tmp/server/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  propertyNameMapper: camelCaser,
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -83,7 +83,7 @@ describe('network ts mappig', () => {
         .success();
       expect(p.extra_property).toEqual('y');
     });
-    
+
     it('maps inputs', async () => {
       const p = types.typeItem
         .maker({ some_property: 'x' } as any, { convertFromNetwork: true })

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -12,20 +12,26 @@ import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
 import axios from 'axios';
 
 describe('network ts mappig', () => {
-  describe('allOf mapping', () => {
-    const input = {
-      overlapping_property: 'y',
-      some_property: 'x',
-      extra_second_property: 'z'
-    };
-    const value = types.typeAllOfSchema.maker(input, { convertFromNetwork: true }).success();
-    expect(value).toEqual({
-      extraSecondProperty: input.extra_second_property,
-      someProperty: input.some_property,
-      overlappingProperty: input.overlapping_property
+  describe('allOf', () => {
+    it('cheks mapped props with all branches of allOf', () => {
+      // todo
+      expect('todo').toEqual('done');
     });
-    const serialized = serialize(value);
-    expect(serialized).toEqual(input);
+    it('maps props', () => {
+      const input = {
+        overlapping_property: 'y',
+        some_property: 'x',
+        extra_second_property: 'z'
+      };
+      const value = types.typeAllOfSchema.maker(input, { convertFromNetwork: true }).success();
+      expect(value).toEqual({
+        extraSecondProperty: input.extra_second_property,
+        someProperty: input.some_property,
+        overlappingProperty: input.overlapping_property
+      });
+      const serialized = serialize(value);
+      expect(serialized).toEqual(input);
+    });
   });
   describe('mapping works', () => {
     it('maps inputs', async () => {

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -35,6 +35,7 @@ describe('network ts mappig', () => {
     const requestParam = 'request path param';
     const replyHeader = 'reply header';
     const requestHeaderItem = 'request header item';
+    const someQueryItem = 'some query item';
     const requestItem: types.ShapeOfItem = {
       someProperty: 'some property of item',
       extraProp: { extraNestedObjectProp: 'xxnn' }
@@ -44,6 +45,7 @@ describe('network ts mappig', () => {
     const spec: server.Endpoints = {
       '/item/{some_item}': {
         post: async ctx => {
+          expect(ctx.query.someQueryItem).toEqual(someQueryItem);
           expect(ctx.headers.headerItem).toEqual(requestHeaderItem);
           expect(ctx.params.someItem).toEqual(requestParam);
           expect(ctx.body.value).toEqual(requestItem);
@@ -112,7 +114,8 @@ describe('network ts mappig', () => {
       it('maps everything', async () => {
         const p = await apiClient.item(requestParam).post({
           headers: { headerItem: requestHeaderItem },
-          body: runtime.client.json(requestItem)
+          body: runtime.client.json(requestItem),
+          query: { someQueryItem }
         });
         expect(p.value.value).toEqual(replyItem);
         expect(p.headers.replyHeader).toEqual(replyHeader);
@@ -120,7 +123,7 @@ describe('network ts mappig', () => {
 
       it('server maps correctly', async () => {
         const p = await axios.post(
-          `${url}/item/${requestParam}`,
+          `${url}/item/${requestParam}?some_query_item=${someQueryItem}`,
           {
             some_property: requestItem.someProperty,
             extra_prop: { extra_nested_object_prop: requestItem.extraProp!.extraNestedObjectProp }

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -51,6 +51,13 @@ describe('network ts mapping', () => {
     });
   });
   describe('allOf', () => {
+    it('handles discriminated objects in allOf', () => {
+      const input: any = { prop_tag: 'one' };
+      const value = types.typeAllOfWithDiscrimination
+        .maker(input, { convertFromNetwork: true })
+        .success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
     it('checks mapped props with all branches of allOf', () => {
       const input = {
         // this is allowed by Item but not by overlapping other ThirdItem

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -2,11 +2,6 @@ import * as types from './tmp/client/types.generated';
 import { serialize } from '../../packages/oats-runtime/src/serialize';
 
 describe('network ts mappig', () => {
-  describe('safe mappig', () => {
-    it('serializes and deserializes', () => {
-
-    });
-  });
   describe('mapping works', () => {
     it('maps inputs', async () => {
       const p = types.typeItem

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -12,6 +12,21 @@ import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
 import axios from 'axios';
 
 describe('network ts mappig', () => {
+  describe('allOf mapping', () => {
+    const input = {
+      overlapping_property: 'y',
+      some_property: 'x',
+      extra_second_property: 'z'
+    };
+    const value = types.typeAllOfSchema.maker(input, { convertFromNetwork: true }).success();
+    expect(value).toEqual({
+      extraSecondProperty: input.extra_second_property,
+      someProperty: input.some_property,
+      overlappingProperty: input.overlapping_property
+    });
+    const serialized = serialize(value);
+    expect(serialized).toEqual(input);
+  });
   describe('mapping works', () => {
     it('maps inputs', async () => {
       const p = types.typeItem

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -19,6 +19,13 @@ describe('network ts mapping', () => {
     });
   });
   describe('oneOf', () => {
+    it('handles mixed discriminated and undiscriminated objects with string value', () => {
+      const input: any = 'string value';
+      const value = types.typeMixedDiscrimination
+        .maker(input, { convertFromNetwork: true })
+        .success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
     it('handles mixed discriminated and undiscriminated objects', () => {
       const input: any = { extra_value: 'one' };
       const value = types.typeMixedDiscrimination

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -10,7 +10,46 @@ import * as client from './tmp/client/generated';
 import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
 import axios from 'axios';
 
-describe('network ts mappig', () => {
+describe('network ts mapping', () => {
+  describe('array', () => {
+    it('maps values inside arrays', () => {
+      const input: any = [{ some_property: 'abc' }];
+      const value = types.typeArraySchema.maker(input, { convertFromNetwork: true }).success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
+  });
+  describe('oneOf', () => {
+    it('handles mixed discriminated and undiscriminated objects', () => {
+      const input: any = { extra_value: 'one' };
+      const value = types.typeMixedDiscrimination
+        .maker(input, { convertFromNetwork: true })
+        .success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
+
+    it('handles discriminated objects', () => {
+      const input: any = { prop_tag: 'one' };
+      const value = types.typeDiscriminated.maker(input, { convertFromNetwork: true }).success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
+
+    it('handles undiscriminated objects', () => {
+      const input: any = { first_value: 'one' };
+      const value = types.typeNonDiscriminatedOneOf
+        .maker(input, { convertFromNetwork: true })
+        .success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
+  });
+  describe('additionalProps', () => {
+    it('serialized names objects as values in additionalProps', () => {
+      const input: any = { some_key: { prop_tag: 'one' } };
+      const value = types.typeAdditionalPropSchema
+        .maker(input, { convertFromNetwork: true })
+        .success();
+      expect(runtime.serialize(value)).toEqual(input);
+    });
+  });
   describe('allOf', () => {
     it('checks mapped props with all branches of allOf', () => {
       const input = {

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -13,10 +13,21 @@ import axios from 'axios';
 
 describe('network ts mappig', () => {
   describe('allOf', () => {
-    it('cheks mapped props with all branches of allOf', () => {
-      // todo
-      expect('todo').toEqual('done');
+    it('checks mapped props with all branches of allOf', () => {
+      const input = {
+        // this is allowed by Item but not by overlapping other ThirdItem
+        overlapping_property: 1,
+        some_property: 'x',
+        extra_second_property: 'z'
+      };
+      expect(types.typeAllOfSchema.maker(input, { convertFromNetwork: true }).errors).toEqual([
+        {
+          error: 'expected a string, but got `1` instead.',
+          path: ['(allOf)', '(allOf)', 'overlappingProperty']
+        }
+      ]);
     });
+
     it('maps props', () => {
       const input = {
         overlapping_property: 'y',

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -77,6 +77,13 @@ describe('network ts mappig', () => {
     });
   });
   describe('mapping works', () => {
+    it('maps inputs but not additional props', async () => {
+      const p = types.typeItem
+        .maker({ some_property: 'x', extra_property: 'y' } as any, { convertFromNetwork: true })
+        .success();
+      expect(p.extra_property).toEqual('y');
+    });
+    
     it('maps inputs', async () => {
       const p = types.typeItem
         .maker({ some_property: 'x' } as any, { convertFromNetwork: true })

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -16,7 +16,7 @@ describe('mapping works', () => {
 
   it('serializes object values', async () => {
     const value = types.typeItem.maker({ someProperty: 'x' }).success();
-    const serialized = serialize(types.typeItem.maker.type!, value);
+    const serialized = serialize(value);
     expect(serialized.some_property).toEqual('x');
   });
 });

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -1,22 +1,29 @@
 import * as types from './tmp/client/types.generated';
-import { serialize } from '@smartlyio/oats-runtime';
+import { serialize } from '../../packages/oats-runtime/src/serialize';
 
-describe('mapping works', () => {
-  it('maps inputs', async () => {
-    const p = types.typeItem
-      .maker({ some_property: 'x' } as any, { convertFromNetwork: true })
-      .success();
-    expect(p.someProperty).toEqual('x');
+describe('network ts mappig', () => {
+  describe('safe mappig', () => {
+    it('serializes and deserializes', () => {
+
+    });
   });
+  describe('mapping works', () => {
+    it('maps inputs', async () => {
+      const p = types.typeItem
+        .maker({ some_property: 'x' } as any, { convertFromNetwork: true })
+        .success();
+      expect(p.someProperty).toEqual('x');
+    });
 
-  it('does not map input unnecessarily', async () => {
-    const p = types.typeItem.maker({ someProperty: 'x' }).success();
-    expect(p.someProperty).toEqual('x');
-  });
+    it('does not map input unnecessarily', async () => {
+      const p = types.typeItem.maker({ someProperty: 'x' }).success();
+      expect(p.someProperty).toEqual('x');
+    });
 
-  it('serializes object values', async () => {
-    const value = types.typeItem.maker({ someProperty: 'x' }).success();
-    const serialized = serialize(value);
-    expect(serialized.some_property).toEqual('x');
+    it('serializes object values', async () => {
+      const value = types.typeItem.maker({ someProperty: 'x' }).success();
+      const serialized = serialize(value);
+      expect(serialized.some_property).toEqual('x');
+    });
   });
 });

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -1,0 +1,22 @@
+import * as types from './tmp/client/types.generated';
+import { serialize } from '@smartlyio/oats-runtime';
+
+describe('mapping works', () => {
+  it('maps inputs', async () => {
+    const p = types.typeItem
+      .maker({ some_property: 'x' } as any, { convertFromNetwork: true })
+      .success();
+    expect(p.someProperty).toEqual('x');
+  });
+
+  it('does not map input unnecessarily', async () => {
+    const p = types.typeItem.maker({ someProperty: 'x' }).success();
+    expect(p.someProperty).toEqual('x');
+  });
+
+  it('serializes object values', async () => {
+    const value = types.typeItem.maker({ someProperty: 'x' }).success();
+    const serialized = serialize(types.typeItem.maker.type!, value);
+    expect(serialized.some_property).toEqual('x');
+  });
+});

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -1,5 +1,15 @@
 import * as types from './tmp/client/types.generated';
 import { serialize } from '../../packages/oats-runtime/src/serialize';
+import * as server from './tmp/server/generated';
+import * as runtime from '@smartlyio/oats-runtime';
+import * as koaAdapter from '@smartlyio/oats-koa-adapter';
+import * as Koa from 'koa';
+import * as koaBody from 'koa-body';
+import http from 'http';
+import { it, expect, afterAll, beforeAll, describe } from '@jest/globals';
+import * as client from './tmp/client/generated';
+import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
+import axios from 'axios';
 
 describe('network ts mappig', () => {
   describe('mapping works', () => {
@@ -19,6 +29,109 @@ describe('network ts mappig', () => {
       const value = types.typeItem.maker({ someProperty: 'x' }).success();
       const serialized = serialize(value);
       expect(serialized.some_property).toEqual('x');
+    });
+  });
+  describe('integration test', () => {
+    const requestParam = 'request path param';
+    const replyHeader = 'reply header';
+    const requestHeaderItem = 'request header item';
+    const requestItem: types.ShapeOfItem = {
+      someProperty: 'some property of item',
+      extraProp: { extraNestedObjectProp: 'xxnn' }
+    };
+    const replyItem: types.ShapeOfItem = { someProperty: 'some reply property of item' };
+
+    const spec: server.Endpoints = {
+      '/item/{some_item}': {
+        post: async ctx => {
+          expect(ctx.headers.headerItem).toEqual(requestHeaderItem);
+          expect(ctx.params.someItem).toEqual(requestParam);
+          expect(ctx.body.value).toEqual(requestItem);
+          return runtime.setHeaders(runtime.json(200, replyItem), {
+            // todo: map reply header types
+            replyHeader: replyHeader
+          });
+        }
+      }
+    };
+
+    function createRoutes() {
+      return koaAdapter.bind({
+        handler: runtime.server.createHandlerFactory<server.Endpoints>(server.endpointHandlers),
+        spec
+      });
+    }
+
+    function createApp() {
+      const app = new Koa();
+      app.use(
+        koaBody({
+          multipart: true
+        })
+      );
+      app.use(createRoutes().routes());
+      return app;
+    }
+
+    function serverPort(server: http.Server) {
+      return serverAddress(server).split(/:/)[2] || 80;
+    }
+
+    function serverAddress(server: http.Server) {
+      const addr = server.address();
+      if (typeof addr === 'string') {
+        return addr;
+      } else if (!addr) {
+        throw new Error('missing server address');
+      }
+
+      return `http://localhost:${addr.port}`;
+    }
+
+    describe('Koa adapter', () => {
+      let apiClient: client.ClientSpec;
+      let httpServer: http.Server | undefined;
+      let url: string;
+
+      afterAll(() => {
+        httpServer?.close();
+      });
+
+      beforeAll(async () => {
+        httpServer = await new Promise<http.Server>(resolve => {
+          const httpServer = createApp().listen(0, () => resolve(httpServer));
+        });
+        const port = serverPort(httpServer);
+        url = `http://localhost:${port}`;
+
+        apiClient = client.client(spec => {
+          return axiosAdapter.create()({ ...spec, servers: [url] });
+        });
+      });
+
+      it('maps everything', async () => {
+        const p = await apiClient.item(requestParam).post({
+          headers: { headerItem: requestHeaderItem },
+          body: runtime.client.json(requestItem)
+        });
+        expect(p.value.value).toEqual(replyItem);
+        expect(p.headers.replyHeader).toEqual(replyHeader);
+      });
+
+      it('server maps correctly', async () => {
+        const p = await axios.post(
+          `${url}/item/${requestParam}`,
+          {
+            some_property: requestItem.someProperty,
+            extra_prop: { extra_nested_object_prop: requestItem.extraProp!.extraNestedObjectProp }
+          },
+          {
+            headers: { header_item: requestHeaderItem }
+          }
+        );
+        expect(p.data).toEqual({ some_property: replyItem.someProperty });
+        expect(p.headers['reply_header']).toEqual(replyHeader);
+      });
     });
   });
 });


### PR DESCRIPTION
allow mapping object properties to and from network and ts formats (ie from snake_case to kebab-case). How this works:

1. We use a user passed mapping function to map from the openapi spec (network format) properties to ts side properties.
2. This map is stored in the reflection types
3. the maker for a type takes a flag to control whether the network-ts mapping should be done
4. this is done if there actually is anything to map (ie the generated code had a mapper)
5. the flag is passed in the endpoint `safe` wrapper when deserializing

for serializing we store a hidden symbol prop in all maker constructed objects that points to the type information for all the types selected for the construction of that object (ie all allOfs that were applied) so we can get the property naming map. This type can be obtained by `getTypes` function which is used by `serialize` function. This hidden symbol will only be present in objects allocated by a oats maker so it will get lost with any `{ ...madeObject }` shenanigans. This I think is ok as we will be calling this directly after making the value in `safe`.

This serializing is done in `safe` depending on are we in client or in server side.

Downside of this scheme is that we add more runtime data and processing which may have some effect at least in the browser side. However I'm not sure how to do bidirectional maps between strings on the fly -- eg consider "foo_ABC", the natural counterpart for that is "fooABC" but what would be the map back?

See https://github.com/smartlyio/oats/pull/338/files#diff-52d4beca09d8f35f84caff3e1d14967026234c009949eb610cec13dc37807cc5R114 for user facing usage example

Note the backwards incompatible change with not lowercasing request headers on client side in order to allow the network property mapping to work. This has been prevented by the typechecker before but it is possible that somebody has by passed the type checker. This will result in the header being dropped. I noted this this in the changelog.

todo
 - [x] make `safe` do (de)serialization
 - [x] pass the direction flag to `safe`
 - [x] test the endpoint logic
 - [x] think through the header lower case change. what happens with additionalprops? Request headers do not allow additional props so this should be ok.