### PR TITLE
Pass parameterised path down to adapters

### DIFF
--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -28,7 +28,16 @@ export interface ClientSpec {
   readonly [part: string]: ClientSpec | PathParam | ClientEndpoint<any, any, any, any>;
 }
 
-export type ClientAdapter = server.SafeEndpoint;
+export type RequestContext = { parameterised_path: string };
+
+export type ClientAdapter = server.Endpoint<
+  Headers | undefined,
+  server.Params | undefined,
+  server.Query | undefined,
+  server.RequestBody<any> | undefined,
+  server.Response<number, any, any, Record<string, any>>,
+  RequestContext
+>;
 export type ClientFactory<Spec> = (adapter: ClientAdapter) => Spec;
 
 interface RequestBody<T, ContentType> {
@@ -177,7 +186,7 @@ function fillInPathParams(params: { [key: string]: string }, path: string) {
 
 function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams: string[]) {
   const params = paramObject(pathParams, handler.path);
-  const call = server.safe(
+  const call = server.safe<any, any, any, any, any, RequestContext>(
     handler.headers,
     handler.params,
     handler.query,
@@ -196,7 +205,7 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
       headers: safe(ctx).headers.$,
       query: safe(ctx).query.$,
       body: safe(ctx).body.$,
-      requestContext: {}
+      requestContext: { parameterised_path: handler.path }
     });
 }
 


### PR DESCRIPTION
currently there's no way to access the parameterised path in the adapter level.
if one wishes to log outbound requests without path parameters one would need to write code to replace them. oats has the value ready, so let's just make it accessible