### PR TITLE
Make oats tag truly private

### DIFF
--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -127,7 +127,7 @@ export function run(options: Options) {
   function generateOatsBrandProperty() {
     return ts.factory.createPropertyDeclaration(
       [ts.factory.createToken(ts.SyntaxKind.ReadonlyKeyword)],
-      ts.factory.createIdentifier(`#${oatsBrandFieldName}`),
+      ts.factory.createPrivateIdentifier(`#${oatsBrandFieldName}`),
       ts.factory.createToken(ts.SyntaxKind.ExclamationToken),
       ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
       undefined

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -126,11 +126,8 @@ export function run(options: Options) {
 
   function generateOatsBrandProperty() {
     return ts.factory.createPropertyDeclaration(
-      [
-        ts.factory.createToken(ts.SyntaxKind.PrivateKeyword),
-        ts.factory.createToken(ts.SyntaxKind.ReadonlyKeyword)
-      ],
-      quotedProp(oatsBrandFieldName),
+      [ts.factory.createToken(ts.SyntaxKind.ReadonlyKeyword)],
+      ts.factory.createIdentifier(`#${oatsBrandFieldName}`),
       ts.factory.createToken(ts.SyntaxKind.ExclamationToken),
       ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
       undefined
@@ -1501,7 +1498,7 @@ export function run(options: Options) {
           return;
         }
       }
-      const brandMatch = line.match(new RegExp('\\s*private readonly ' + oatsBrandFieldName));
+      const brandMatch = line.match(new RegExp('\\s*readonly #' + oatsBrandFieldName));
       if (brandMatch) {
         result.push('    // @ts-ignore tsc does not like unused privates');
         result.push(line);


### PR DESCRIPTION
generated class after this change:
```ts
export class Error extends oar.valueClass.ValueClass {
    readonly message!: string;
    readonly messageIndex!: number;
    // @ts-ignore tsc does not like unused privates
    readonly #__oats_value_class_brand_tag!: string;
    readonly [instanceIndexSignatureKey: string]: unknown;
    public constructor(value: ShapeOfError, opts?: oar.make.MakeOptions | InternalUnsafeConstructorOption) { super(); oar.instanceAssign(this, value, opts, buildError); }
    public static reflection: oar.reflection.NamedTypeDefinitionDeferred<Error> = () => { return typeError; };
    static make(value: ShapeOfError, opts?: oar.make.MakeOptions): oar.make.Make<Error> { const make = buildError(value, opts); if (make.isError())
        return oar.make.Make.error(make.errors);
    else
        return oar.make.Make.ok(new Error(make.success(), { unSafeSet: true })); }
}
```