### PR TITLE
actually drop undefined for unknown additionalprops

### DIFF
--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -473,18 +473,20 @@ export function makeObject<
       if (props[index]) {
         continue;
       }
-      if (!additionalProp) {
-        if (safe(opts).unknownField.$ === 'drop') {
-          continue;
-        }
-        return error('unexpected property').errorPath(index);
-      }
+
       // if additionalProperties allows any value then we skip props with undefined value
       // when additionalProperties is an object we SHOULD drop it
       // when additionalProperties is false we SHOULD drop it
       // when additionalProperties is true we should NOT drop it
       if (type?.additionalProperties !== true && value[index] === undefined) {
         continue;
+      }
+
+      if (!additionalProp) {
+        if (safe(opts).unknownField.$ === 'drop') {
+          continue;
+        }
+        return error('unexpected property').errorPath(index);
       }
       // If the input value A has been made already with network prop name mapping
       // this runs the property value through the current additionalProps maker to validate it

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -822,6 +822,33 @@ describe('object', () => {
     expect(fun({ a: 1 }).success()).toEqual({ a: 1 });
   });
 
+  it('does not remove undefined props when additionalProps true', () => {
+    const fun = make.fromReflection({
+      type: 'object',
+      additionalProperties: true,
+      properties: {}
+    });
+    expect(Object.keys(fun({ a: undefined }).success())).toEqual(['a']);
+  });
+
+  it('removes undefined props when additionalProps is a type', () => {
+    const fun = make.fromReflection({
+      type: 'object',
+      additionalProperties: { type: 'string' },
+      properties: {}
+    });
+    expect(Object.keys(fun({ a: undefined }).success())).toEqual([]);
+  });
+
+  it('removes unknown undefined props when additionalProps is false', () => {
+    const fun = make.fromReflection({
+      type: 'object',
+      additionalProperties: false,
+      properties: {}
+    });
+    expect(Object.keys(fun({ a: undefined }).success())).toEqual([]);
+  });
+
   it('allows undefined props', () => {
     const fun = make.fromReflection({
       type: 'object',


### PR DESCRIPTION
in case additionalProperties: false we did not drop undefined props like we planned. Now we do.