### PR TITLE
If no headers are defined, generate type as `Record<string, string|undefined>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "client"
   ],
   "devDependencies": {
-    "@smartlyio/safe-navigation": "5.0.2",
     "@types/jest": "29.5.0",
     "@types/koa": "2.13.6",
     "@types/koa-mount": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "jest --watch",
     "lint:local": "eslint --max-warnings=0 --ext .ts test examples",
     "lint": "yarn lint:local && lerna run lint",
+    "lint:fix": "yarn lint:local && lerna run lint:fix",
     "generate": "yarn generate:examples && yarn generate:test",
     "generate:test": "find test -name 'driver.ts' -exec ts-node -r tsconfig-paths/register --project tsconfig.json {} \\;",
     "generate:examples": "ts-node -r tsconfig-paths/register --project tsconfig.json examples/driver.ts && ts-node -r tsconfig-paths/register --project tsconfig.json render.ts",

--- a/packages/oats-fast-check/package.json
+++ b/packages/oats-fast-check/package.json
@@ -25,7 +25,6 @@
     "typescript": "^4.8.0 || ^5.0.0"
   },
   "dependencies": {
-    "@smartlyio/safe-navigation": "^5.0.1",
     "lodash": "^4.17.20",
     "randexp": "^0.5.3"
   },

--- a/packages/oats-nock-adapter/package.json
+++ b/packages/oats-nock-adapter/package.json
@@ -25,7 +25,6 @@
     "typescript": "^4.8.0 || ^5.0.0"
   },
   "dependencies": {
-    "@smartlyio/safe-navigation": "^5.0.2",
     "lodash": "^4.17.20"
   },
   "keywords": [

--- a/packages/oats-nock-adapter/test/server.spec.ts
+++ b/packages/oats-nock-adapter/test/server.spec.ts
@@ -231,7 +231,7 @@ describe('server', () => {
               return runtime.json(
                 200,
                 types.Item.make({
-                  id: ctx.body.value.someValue + ' ' + ctx.body.value.blob.options
+                  id: ctx.body.value.someValue + ' ' + ctx.body.value.blob?.options
                 }).success()
               );
             }

--- a/packages/oats-nock-adapter/test/server.spec.ts
+++ b/packages/oats-nock-adapter/test/server.spec.ts
@@ -1,7 +1,6 @@
 import * as nockAdapter from '../src/nock';
 import * as axiosClient from '@smartlyio/oats-axios-adapter';
 import * as runtime from '@smartlyio/oats-runtime';
-import safe from '@smartlyio/safe-navigation';
 
 import * as api from '../tmp/client.types.generated';
 import * as types from '../tmp/openapi.types.generated';
@@ -232,7 +231,7 @@ describe('server', () => {
               return runtime.json(
                 200,
                 types.Item.make({
-                  id: ctx.body.value.someValue + ' ' + safe(ctx).body.value.blob.options.$
+                  id: ctx.body.value.someValue + ' ' + ctx.body.value.blob.options
                 }).success()
               );
             }

--- a/packages/oats-nock-adapter/test/server.spec.ts
+++ b/packages/oats-nock-adapter/test/server.spec.ts
@@ -228,10 +228,12 @@ describe('server', () => {
         nockAdapter.bind(api.createRouter(), {
           '/item/formdata': {
             post: async ctx => {
+              const blob = ctx.body.value.blob;
+              const options = blob && 'options' in blob ? blob.options : undefined;
               return runtime.json(
                 200,
                 types.Item.make({
-                  id: ctx.body.value.someValue + ' ' + ctx.body.value.blob?.options
+                  id: ctx.body.value.someValue + ' ' + options
                 }).success()
               );
             }

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.8.0 || ^5.0.0"
   },
   "dependencies": {
-    "@smartlyio/safe-navigation": "^5.0.1",
+    "@smartlyio/safe-navigation": "^5.1.0",
     "@types/encodeurl": "1.0.0",
     "@types/escape-html": "1.0.2",
     "encodeurl": "1.0.2",

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -12,7 +12,8 @@
     "clean:dist": "rm -rf ./dist",
     "prebuild": "yarn clean && yarn tsc --project tsconfig.test.json --noEmit",
     "build": "yarn tsc",
-    "lint": "eslint --max-warnings=0 --ext .ts src test"
+    "lint": "eslint --max-warnings=0 --ext .ts src test",
+    "lint:fix": "eslint --max-warnings=0 --ext .ts src test --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -1,5 +1,4 @@
 import * as server from './server';
-import safe from '@smartlyio/safe-navigation';
 import { assert } from './assert';
 
 type HasOnlyOptionalTypes<O> = Partial<O> extends O ? true : O extends void ? true : false;
@@ -98,7 +97,7 @@ export function addPath<T>(
     const part = parts[0];
     if (part === undefined) {
       assert(
-        safe(opTree).methods[method].$ === undefined,
+        opTree.methods[method] === undefined,
         'duplicate method definition for ' + path
       );
       return {
@@ -120,7 +119,7 @@ export function addPath<T>(
           ...opTree,
           param: {
             name: identifier(param[2]),
-            tree: addPath_(parts.slice(1), safe(opTree).param.tree.$)
+            tree: addPath_(parts.slice(1), opTree.param?.tree)
           }
         };
       } else {
@@ -202,9 +201,9 @@ function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams:
       servers: handler.servers,
       method: handler.method,
       params,
-      headers: safe(ctx).headers.$,
-      query: safe(ctx).query.$,
-      body: safe(ctx).body.$,
+      headers: ctx?.headers,
+      query: ctx?.query,
+      body: ctx?.body,
       requestContext: { path: handler.path }
     });
 }

--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -96,10 +96,7 @@ export function addPath<T>(
     opTree = opTree || emptyTree();
     const part = parts[0];
     if (part === undefined) {
-      assert(
-        opTree.methods[method] === undefined,
-        'duplicate method definition for ' + path
-      );
+      assert(opTree.methods[method] === undefined, 'duplicate method definition for ' + path);
       return {
         ...opTree,
         methods: {

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -1,5 +1,4 @@
 import { assert, fail } from './assert';
-import safe from '@smartlyio/safe-navigation';
 import * as _ from 'lodash';
 import { isEqual, uniq } from 'lodash';
 import { ValueClass } from './value-class';
@@ -489,7 +488,7 @@ export function makeObject<
       }
 
       if (!additionalProp) {
-        if (safe(opts).unknownField.$ === 'drop') {
+        if (opts?.unknownField === 'drop') {
           continue;
         }
         return error('unexpected property').errorPath(index);

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -1,5 +1,4 @@
 import { assert } from './assert';
-import safeNavigation from '@smartlyio/safe-navigation';
 import { Make, MakeOptions, Maker, ValidationError, validationErrorPrinter } from './make';
 import { serialize } from './serialize';
 
@@ -338,7 +337,7 @@ export function createHandlerFactory<Spec extends Record<string, any>>(
         const endpoint: MethodHandlers = (spec as any)[path];
         Object.keys(endpoint).forEach(method => {
           const methodHandler = (endpoint as any)[method];
-          const endpointWrapper = safeNavigation(tree)[path][method].$;
+          const endpointWrapper = tree?.[path]?.[method];
           assert(endpointWrapper, 'unknown endpoint ' + method.toUpperCase() + ' ' + path);
           adapter(
             path,

--- a/packages/oats/package.json
+++ b/packages/oats/package.json
@@ -24,7 +24,6 @@
     "typescript": "^4.8.0 || ^5.0.0"
   },
   "dependencies": {
-    "@smartlyio/safe-navigation": "^5.0.1",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.20",
     "openapi3-ts": "^3.0.0"

--- a/packages/oats/package.json
+++ b/packages/oats/package.json
@@ -13,7 +13,8 @@
     "clean": "rm -rf ./dist/* && rm -rf ./tmp && find test -name '*generated.ts' -exec rm {} \\;",
     "prebuild": "yarn clean",
     "build": "yarn tsc",
-    "lint": "eslint --max-warnings=0 --ext .ts src test"
+    "lint": "eslint --max-warnings=0 --ext .ts src test",
+    "lint:fix": "eslint --max-warnings=0 --ext .ts src test --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/oats/src/generate-server.ts
+++ b/packages/oats/src/generate-server.ts
@@ -3,7 +3,6 @@ import * as ts from 'typescript';
 import * as assert from 'assert';
 import * as oautil from './util';
 import { server, client } from '@smartlyio/oats-runtime';
-import safe from '@smartlyio/safe-navigation';
 import { NameMapper, UnsupportedFeatureBehaviour } from './util';
 
 function generateRuntimeImport(runtimeModule: string) {
@@ -51,7 +50,7 @@ function generateMethod<S extends oas.OperationObject>(
   opts: Options
 ) {
   if (
-    (safe(opts).unsupportedFeatures.security.$ ?? UnsupportedFeatureBehaviour.reject) ===
+    (opts?.unsupportedFeatures?.security ?? UnsupportedFeatureBehaviour.reject) ===
     UnsupportedFeatureBehaviour.reject
   ) {
     assert(!schema.security, 'security not supported');
@@ -142,7 +141,7 @@ function generateClientMethod(
   op: oas.OperationObject
 ): ts.TypeNode {
   if (
-    (safe(opts).unsupportedFeatures.security.$ ?? UnsupportedFeatureBehaviour.reject) ===
+    (opts?.unsupportedFeatures?.security ?? UnsupportedFeatureBehaviour.reject) ===
     UnsupportedFeatureBehaviour.reject
   ) {
     assert(!op.security, 'security not supported');
@@ -350,7 +349,7 @@ function flattenPathAndMethod(paths: oas.PathsObject) {
 
 function generateHandler(opts: Options) {
   const schema = opts.oas;
-  const servers = (safe(schema).servers.$ || []).map(server => server.url);
+  const servers = (schema?.servers ?? []).map(server => server.url);
   return ts.factory.createVariableStatement(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     ts.factory.createVariableDeclarationList(

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -401,7 +401,10 @@ export function run(options: Options) {
                     }
                   }
                 ),
-            headers: { type: 'object' }
+            headers: {
+              type: 'object',
+              additionalProperties: { type: 'string' }
+            }
           },
           required: ['status', 'value', 'headers'],
           additionalProperties: false

--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -1,6 +1,5 @@
 import * as oas from 'openapi3-ts';
 import * as ts from 'typescript';
-import safe from '@smartlyio/safe-navigation';
 import * as _ from 'lodash';
 import * as assert from 'assert';
 import * as oautil from './util';
@@ -1310,7 +1309,7 @@ export function run(options: Options) {
 
   function generateComponentSchemas(opts: Options): ts.Node[] {
     const oas = opts.oas;
-    const schemas = safe(oas).components.schemas.$;
+    const schemas = oas.components?.schemas;
     if (!schemas) {
       return [];
     }
@@ -1340,17 +1339,17 @@ export function run(options: Options) {
   }
 
   function generateComponents(opts: Options): ts.NodeArray<ts.Node> {
-    const oas = safe(opts.oas);
+    const oas = opts.oas;
     const nodes = [];
     nodes.push(...oautil.errorTag('in component.schemas', () => generateComponentSchemas(opts)));
     nodes.push(
       ...oautil.errorTag('in component.responses', () =>
-        generateComponentRequestsAndResponses(oas.components.responses.$)
+        generateComponentRequestsAndResponses(oas.components?.responses)
       )
     );
     nodes.push(
       ...oautil.errorTag('in component.requestBodies', () =>
-        generateComponentRequestsAndResponses(oas.components.requestBodies.$)
+        generateComponentRequestsAndResponses(oas.components?.requestBodies)
       )
     );
     return ts.factory.createNodeArray(nodes);
@@ -1449,9 +1448,9 @@ export function run(options: Options) {
   ): { qualified?: ts.Identifier; member: string } {
     const external = options.resolve(ref, options, kind);
     if (external) {
-      const importAs = safe(external).importAs.$;
-      if (importAs) {
-        addToImports(importAs, safe(external).importFrom.$, safe(external).generate.$);
+      if ('importAs' in external) {
+        const importAs = external.importAs;
+        addToImports(importAs, external.importFrom, external.generate);
         return { member: external.name, qualified: ts.factory.createIdentifier(importAs) };
       }
       return { member: external.name };

--- a/packages/oats/src/util.ts
+++ b/packages/oats/src/util.ts
@@ -1,5 +1,4 @@
 import * as oas from 'openapi3-ts';
-import safe from '@smartlyio/safe-navigation';
 import * as assert from 'assert';
 import * as _ from 'lodash';
 
@@ -93,7 +92,7 @@ export enum UnsupportedFeatureBehaviour {
 }
 
 function resolve(key: string, schema: oas.OpenAPIObject): oas.SchemaObject | undefined {
-  const hit = safe(schema).components.schemas[key].$;
+  const hit = schema.components?.schemas?.[key];
   if (!hit) {
     return undefined;
   }

--- a/test/reflection/reflection-type.spec.ts
+++ b/test/reflection/reflection-type.spec.ts
@@ -3,7 +3,7 @@ import { reflection as reflectionType } from '@smartlyio/oats-runtime';
 import * as fc from 'fast-check';
 import { generator as gen } from '@smartlyio/oats-fast-check';
 import * as testType from './tmp/fixture.types.generated';
-import safe from '@smartlyio/safe-navigation';
+
 const { createMakerWith, makeArray, makeObject, makeString } = runtime.make;
 const ValueClass = runtime.valueClass.ValueClass;
 type Make<A> = runtime.make.Make<A>;
@@ -530,12 +530,12 @@ describe('reflection-type', () => {
               fc.asyncProperty(
                 gen.named(testType.typeTestObject),
                 async (value: testType.TestObject) => {
-                  const original = safe(value).recursive.noHit.$;
+                  const original = value.recursive?.noHit;
                   const mappedValue: testType.TestObject = await traverser[call](
                     value,
                     (str: any) => ('mapped ' + str) as any
                   );
-                  expect(safe(mappedValue).recursive.noHit.$).toEqual(original);
+                  expect(mappedValue.recursive?.noHit).toEqual(original);
                 }
               )
             ));
@@ -545,12 +545,12 @@ describe('reflection-type', () => {
               fc.asyncProperty(
                 gen.named(testType.typeTestObject),
                 async (value: testType.TestObject) => {
-                  const original = safe(value).recursive.immediate.$;
+                  const original = value.recursive?.immediate;
                   const mappedValue: testType.TestObject = await traverser[call](
                     value,
                     (str: any) => ('mapped ' + str) as any
                   );
-                  expect(safe(mappedValue).recursive.immediate.$).toEqual(
+                  expect(mappedValue.recursive?.immediate).toEqual(
                     original !== undefined ? 'mapped ' + original : undefined
                   );
                 }


### PR DESCRIPTION
If one header is defined the generated type is:
```ts
    readonly headers: {
        readonly etag: string;
        readonly [key: string]: string | undefined;
    };
```

but if no header is the defined the type is:
```ts
    readonly headers: {};
```

with this PR the generated type if no headers are defined will be:
```ts
    readonly headers: {
        readonly [key: string]: string | undefined;
    };
```
which, in my opinion, is the expected behaviour given the first scenario