### PR TITLE
Fix oats fetch adapter

### DIFF
--- a/packages/oats-fetch-adapter/index.ts
+++ b/packages/oats-fetch-adapter/index.ts
@@ -69,7 +69,11 @@ export function create(): runtime.client.ClientAdapter {
 
     Object.entries(arg.query ?? {})
       .filter(([, value]) => !!value)
-      .forEach(([key, value]) => url.searchParams.append(key, `${value}`));
+      .forEach(([key, value]) =>
+        Array.isArray(value)
+          ? value.forEach(v => url.searchParams.append(key, `${v}`))
+          : url.searchParams.append(key, `${value}`)
+      );
 
     const response = await fetch(
       new Request(url.toString(), {

--- a/test/fetch-adapter/api.yml
+++ b/test/fetch-adapter/api.yml
@@ -28,6 +28,23 @@ paths:
             text/plain:
               schema:
                 type: string
+  /with-array-query:
+    get:
+      parameters:
+        - in: query
+          name: numbers
+          schema:
+            type: array
+            items:
+              type: string
+      description: endpoint
+      responses:
+        200:
+          description: endpoint
+          content:
+            text/plain:
+              schema:
+                type: string
   /with-headers:
     get:
       parameters:

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -98,6 +98,22 @@ describe('fetch adapter', () => {
     expect(receivedContext.body).toEqual(null);
   });
 
+  it('correctly calls GET request with array in query parameters', async () => {
+    const response = await apiClient['with-array-query'].get({
+      query: { numbers: ['one', 'two'] }
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.value.value).toBe('done');
+
+    expect(receivedContext).toBeDefined();
+    expect(receivedContext.method).toEqual('get');
+    expect(receivedContext.path).toEqual('/with-array-query');
+    expect(receivedContext.query).toEqual({ numbers: ['one', 'two'] });
+    expect(receivedContext.headers).toEqual(null);
+    expect(receivedContext.body).toEqual(null);
+  });
+
   it('correctly calls GET request with header parameters', async () => {
     const response = await apiClient['with-headers'].get({
       headers: { one: 'the loneliest number' }


### PR DESCRIPTION
We're turning arrays into strings wrong when parsing query parameters