### PR TITLE
Add body make options for client & server so clients can define how to handle values

### DIFF
--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -180,7 +180,12 @@ function fillInPathParams(params: { [key: string]: string }, path: string) {
   });
 }
 
-function makeMethod(adapter: ClientAdapter, handler: server.Handler, pathParams: string[], opts?: server.HandlerOptions) {
+function makeMethod(
+  adapter: ClientAdapter,
+  handler: server.Handler,
+  pathParams: string[],
+  opts?: server.HandlerOptions
+) {
   const params = paramObject(pathParams, handler.path);
   const call = server.safe<any, any, any, any, any, RequestContext>(
     handler.headers,
@@ -223,7 +228,10 @@ function fromTree(
   return node;
 }
 
-export function createClientFactory<Spec>(handlers: server.Handler[], opts?: server.HandlerOptions): ClientFactory<Spec> {
+export function createClientFactory<Spec>(
+  handlers: server.Handler[],
+  opts?: server.HandlerOptions
+): ClientFactory<Spec> {
   return (adapter: ClientAdapter): Spec => {
     const tree: OpTree<server.Handler> = handlers.reduce((memo, handler) => {
       return addPath(memo, handler.path, handler.method, handler);

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -204,7 +204,7 @@ export function safe<
       ),
       body: getOutBody<Body>(
         mode,
-        body(voidify(ctx.body), internalMakeOptions).success(
+        body(voidify(ctx.body), { ...validationOptions.body, ...internalMakeOptions }).success(
           throwRequestValidationError.bind(null, 'body')
         )
       ),
@@ -323,6 +323,7 @@ export interface HandlerOptions {
   validationOptions?: {
     query?: MakeOptions;
     params?: MakeOptions;
+    body?: MakeOptions;
   };
 }
 

--- a/packages/oats/package.json
+++ b/packages/oats/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^6.0.0",
+    "@smartlyio/oats-runtime": "^6.3.1",
     "typescript": "^4.8.0 || ^5.0.0"
   },
   "dependencies": {

--- a/packages/oats/src/generate-server.ts
+++ b/packages/oats/src/generate-server.ts
@@ -509,24 +509,6 @@ export function generateCreateRouter() {
                             ts.factory.createStringLiteral('fail')
                           ),
                           ts.factory.createBindingElement(
-                            undefined,
-                            'parseBooleanStrings',
-                            'bodyParseBooleanStrings',
-                            ts.factory.createTrue()
-                          ),
-                          ts.factory.createBindingElement(
-                            undefined,
-                            'parseNumericStrings',
-                            'bodyParseNumericStrings',
-                            ts.factory.createTrue()
-                          ),
-                          ts.factory.createBindingElement(
-                            undefined,
-                            'allowConvertForArrayType',
-                            'bodyAllowConvertForArrayType',
-                            ts.factory.createTrue()
-                          ),
-                          ts.factory.createBindingElement(
                             ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
                             undefined,
                             'bodyRest'
@@ -609,18 +591,6 @@ export function generateCreateRouter() {
                         ts.factory.createPropertyAssignment(
                           'unknownField',
                           ts.factory.createIdentifier('bodyUnknownField')
-                        ),
-                        ts.factory.createPropertyAssignment(
-                          'parseBooleanStrings',
-                          ts.factory.createIdentifier('bodyParseBooleanStrings')
-                        ),
-                        ts.factory.createPropertyAssignment(
-                          'parseNumericStrings',
-                          ts.factory.createIdentifier('bodyParseNumericStrings')
-                        ),
-                        ts.factory.createPropertyAssignment(
-                          'allowConvertForArrayType',
-                          ts.factory.createIdentifier('bodyAllowConvertForArrayType')
                         )
                       ])
                     )

--- a/packages/oats/src/generate-server.ts
+++ b/packages/oats/src/generate-server.ts
@@ -499,6 +499,42 @@ export function generateCreateRouter() {
                         ts.factory.createObjectLiteralExpression()
                       ),
                       ts.factory.createBindingElement(
+                        undefined,
+                        'body',
+                        ts.factory.createObjectBindingPattern([
+                          ts.factory.createBindingElement(
+                            undefined,
+                            'unknownField',
+                            'bodyUnknownField',
+                            ts.factory.createStringLiteral('fail')
+                          ),
+                          ts.factory.createBindingElement(
+                            undefined,
+                            'parseBooleanStrings',
+                            'bodyParseBooleanStrings',
+                            ts.factory.createTrue()
+                          ),
+                          ts.factory.createBindingElement(
+                            undefined,
+                            'parseNumericStrings',
+                            'bodyParseNumericStrings',
+                            ts.factory.createTrue()
+                          ),
+                          ts.factory.createBindingElement(
+                            undefined,
+                            'allowConvertForArrayType',
+                            'bodyAllowConvertForArrayType',
+                            ts.factory.createTrue()
+                          ),
+                          ts.factory.createBindingElement(
+                            ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
+                            undefined,
+                            'bodyRest'
+                          )
+                        ]),
+                        ts.factory.createObjectLiteralExpression()
+                      ),
+                      ts.factory.createBindingElement(
                         ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
                         undefined,
                         'validationOptionsRest'
@@ -565,7 +601,29 @@ export function generateCreateRouter() {
                           ts.factory.createIdentifier('paramsParseNumericStrings')
                         )
                       ])
-                    )
+                    ),
+                    ts.factory.createPropertyAssignment(
+                      'body',
+                      ts.factory.createObjectLiteralExpression([
+                        ts.factory.createSpreadAssignment(ts.factory.createIdentifier('bodyRest')),
+                        ts.factory.createPropertyAssignment(
+                          'unknownField',
+                          ts.factory.createIdentifier('bodyUnknownField')
+                        ),
+                        ts.factory.createPropertyAssignment(
+                          'parseBooleanStrings',
+                          ts.factory.createIdentifier('bodyParseBooleanStrings')
+                        ),
+                        ts.factory.createPropertyAssignment(
+                          'parseNumericStrings',
+                          ts.factory.createIdentifier('bodyParseNumericStrings')
+                        ),
+                        ts.factory.createPropertyAssignment(
+                          'allowConvertForArrayType',
+                          ts.factory.createIdentifier('bodyAllowConvertForArrayType')
+                        )
+                      ])
+                    ),
                   ])
                 )
               ])
@@ -608,6 +666,48 @@ export function generateClient() {
   );
 }
 
+export function generateCreateClient() {
+  return ts.factory.createFunctionDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    undefined,
+    'createClient',
+    [],
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        'handlerOptions',
+        undefined,
+        ts.factory.createTypeReferenceNode(
+          ts.factory.createIdentifier('oar.server.HandlerOptions')
+        ),
+        ts.factory.createObjectLiteralExpression()
+      )
+    ],
+    ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('oar.client.ClientFactory'),
+      [ts.factory.createTypeReferenceNode('ClientSpec', [])] 
+    ),
+    ts.factory.createBlock(
+      [
+        ts.factory.createReturnStatement(
+          ts.factory.createCallExpression(
+            ts.factory.createPropertyAccessExpression(
+              ts.factory.createIdentifier('oar'),
+              'client.createClientFactory'
+            ),
+            undefined,
+            [
+              ts.factory.createIdentifier('endpointHandlers'),
+              ts.factory.createIdentifier('handlerOptions')
+            ]
+          )
+        )
+      ],
+      false
+    )
+  );
+}
+
 interface Options {
   oas: oas.OpenAPIObject;
   runtimePath: string;
@@ -633,6 +733,7 @@ export function run(opts: Options) {
   const router = generateRouter();
   const createRouter = generateCreateRouter();
   const client = generateClient();
+  const createClient = generateCreateClient();
 
   const sourceFile: ts.SourceFile = ts.createSourceFile(
     'test.ts',
@@ -654,7 +755,8 @@ export function run(opts: Options) {
         routerJSDoc,
         router,
         createRouter,
-        client
+        client,
+        createClient
       ]),
       sourceFile
     );

--- a/packages/oats/src/generate-server.ts
+++ b/packages/oats/src/generate-server.ts
@@ -623,7 +623,7 @@ export function generateCreateRouter() {
                           ts.factory.createIdentifier('bodyAllowConvertForArrayType')
                         )
                       ])
-                    ),
+                    )
                   ])
                 )
               ])
@@ -684,9 +684,9 @@ export function generateCreateClient() {
         ts.factory.createObjectLiteralExpression()
       )
     ],
-    ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('oar.client.ClientFactory'),
-      [ts.factory.createTypeReferenceNode('ClientSpec', [])] 
-    ),
+    ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('oar.client.ClientFactory'), [
+      ts.factory.createTypeReferenceNode('ClientSpec', [])
+    ]),
     ts.factory.createBlock(
       [
         ts.factory.createReturnStatement(

--- a/test/request-parsing/api.yml
+++ b/test/request-parsing/api.yml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: example service
+servers:
+  - url: http://localhost:12000
+paths:
+  /item:
+    post:
+      description: create an item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                requiredField:
+                  type: string
+                optionalField:
+                  type: string
+              required:
+                - requiredField
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/test/request-parsing/client-body.spec.ts
+++ b/test/request-parsing/client-body.spec.ts
@@ -1,0 +1,78 @@
+// yarn ts-node examples/server.ts
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import * as server from './tmp/server/generated';
+import * as client from './tmp/client/generated';
+import * as runtime from '@smartlyio/oats-runtime';
+import * as koaAdapter from '@smartlyio/oats-koa-adapter';
+import * as Koa from 'koa';
+import { koaBody } from 'koa-body';
+import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+describe('client body', () => {
+  const getRoutes = () =>
+    koaAdapter.bind(
+      server.createRouter({ validationOptions: { body: { unknownField: 'fail' } } }),
+      {
+        '/item': {
+          post: async ctx => {
+            return runtime.json(200, { body: ctx.body.value });
+          }
+        }
+      }
+    );
+  const createApp = () => {
+    const app = new Koa();
+    app.use(koaBody({ multipart: true }));
+    app.use(getRoutes().routes());
+    return app;
+  };
+
+  const createServer = async () => {
+    const httpServer = await new Promise<http.Server>(resolve => {
+      const server = createApp().listen(0, () => resolve(server));
+    });
+    const { port } = httpServer.address() as AddressInfo;
+    const clientSpec = client.createClient({
+      validationOptions: { body: { unknownField: 'drop' } }
+    })(spec => {
+      return axiosAdapter.create()({ ...spec, servers: [`http://localhost:${port}`] });
+    });
+    return {
+      httpServer,
+      clientSpec
+    };
+  };
+
+  let httpServer: http.Server;
+  let clientSpec: client.ClientSpec;
+  beforeAll(async () => {
+    const response = await createServer();
+    httpServer = response.httpServer;
+    clientSpec = response.clientSpec;
+  });
+
+  afterAll(() => {
+    httpServer?.close();
+  });
+
+  it('should drop all unknown values before sending request to server when dropping unknown fields', async () => {
+    const body = {
+      thisIsUnkownProperty: 'value',
+      requiredField: 'xxx',
+      optionalField: 'yyy'
+    } as any;
+    const actual = await clientSpec.item.post({
+      body: runtime.client.json(body)
+    });
+
+    expect(actual.status).toBe(200);
+    expect(actual.value.value).toEqual({
+      body: {
+        requiredField: 'xxx',
+        optionalField: 'yyy'
+      }
+    });
+  });
+});

--- a/test/request-parsing/driver.ts
+++ b/test/request-parsing/driver.ts
@@ -1,0 +1,19 @@
+import { driver } from '@smartlyio/oats';
+import * as process from 'process';
+
+process.chdir(__dirname);
+driver.generate({
+  generatedValueClassFile: './tmp/client/types.generated.ts',
+  generatedClientFile: './tmp/client/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});
+
+driver.generate({
+  generatedValueClassFile: './tmp/server/types.generated.ts',
+  generatedServerFile: './tmp/server/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api.yml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});

--- a/test/request-parsing/server-body.spec.ts
+++ b/test/request-parsing/server-body.spec.ts
@@ -1,0 +1,80 @@
+// yarn ts-node examples/server.ts
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import * as server from './tmp/server/generated';
+import * as runtime from '@smartlyio/oats-runtime';
+import * as koaAdapter from '@smartlyio/oats-koa-adapter';
+import * as Koa from 'koa';
+import { koaBody } from 'koa-body';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { Axios } from 'axios';
+
+describe('server body', () => {
+  const getRoutes = () =>
+    koaAdapter.bind(
+      server.createRouter({ validationOptions: { body: { unknownField: 'drop' } } }),
+      {
+        '/item': {
+          post: async ctx => {
+            return runtime.json(200, { body: ctx.body.value });
+          }
+        }
+      }
+    );
+  const createApp = () => {
+    const app = new Koa();
+    app.use(koaBody({ multipart: true }));
+    app.use(getRoutes().routes());
+    return app;
+  };
+
+  const createServer = async () => {
+    const httpServer = await new Promise<http.Server>(resolve => {
+      const server = createApp().listen(0, () => resolve(server));
+    });
+    const { port } = httpServer.address() as AddressInfo;
+    const axios = new Axios({
+      baseURL: `http://localhost:${port}`
+    });
+    return {
+      httpServer,
+      axios
+    };
+  };
+
+  let httpServer: http.Server;
+  let axios: Axios;
+  beforeAll(async () => {
+    const response = await createServer();
+    httpServer = response.httpServer;
+    axios = response.axios;
+  });
+
+  afterAll(() => {
+    httpServer?.close();
+  });
+
+  it('should drop all unknown values and process request when dropping unknown fields', async () => {
+    const actual = await axios.post(
+      '/item',
+      JSON.stringify({
+        thisIsUnkownProperty: 'value',
+        requiredField: 'xxx',
+        optionalField: 'yyy'
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    expect(actual.status).toBe(200);
+    expect(JSON.parse(actual.data)).toEqual({
+      body: {
+        requiredField: 'xxx',
+        optionalField: 'yyy'
+      }
+    });
+  });
+});


### PR DESCRIPTION
Clients of `client` & `server` implementations can define what to do with unknown fields; to throw error or just drop fields.