### PR TITLE
Change drop option to behave the same way 'fail' would when matching to schema

### DIFF
--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -352,7 +352,7 @@ export function makeOneOf(...options: any[]) {
             return error('multiple preferred options match');
           }
           preferredSuccess = mapped;
-        } else if (0 < success.length) {
+        } else if (success.length > 0) {
           if (opts?.unknownField === 'drop') {
             success.push(mapped);
           } else {
@@ -384,7 +384,7 @@ export function makeOneOf(...options: any[]) {
 }
 
 function isMultipleMatchesFound(mapped: any[]): boolean {
-  return 1 < mapped.length;
+  return mapped.length > 1;
 }
 
 function findBestMatch(mapped: any[]): any {

--- a/test/request-parsing/api.yml
+++ b/test/request-parsing/api.yml
@@ -4,6 +4,26 @@ info:
   title: example service
 servers:
   - url: http://localhost:12000
+components:
+  schemas:
+    typeA:
+      type: object
+      additionalProperties: false
+      properties:
+        field_a:
+          type: string
+        field_b:
+          type: string
+    typeB:
+      type: object
+      additionalProperties: false
+      properties:
+        field_a:
+          type: string
+    typeUnion:
+      oneOf:
+        - $ref: '#/components/schemas/typeA'
+        - $ref: '#/components/schemas/typeB'
 paths:
   /item:
     post:
@@ -20,6 +40,8 @@ paths:
                   type: string
                 optionalField:
                   type: string
+                typeUnion:
+                  $ref: "#/components/schemas/typeUnion"
               required:
                 - requiredField
       responses:

--- a/test/request-parsing/server-body.spec.ts
+++ b/test/request-parsing/server-body.spec.ts
@@ -77,4 +77,57 @@ describe('server body', () => {
       }
     });
   });
+
+  it('should drop unknown fields and match to closest schema', async () => {
+    const actual = await axios.post(
+      '/item',
+      JSON.stringify({
+        requiredField: 'xxx',
+        optionalField: 'yyy',
+        typeUnion: {
+          field_a: 'a',
+          field_b: 'b',
+          unknownField: true
+        }
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    expect(actual.status).toBe(200);
+    expect(JSON.parse(actual.data)).toEqual({
+      body: {
+        requiredField: 'xxx',
+        optionalField: 'yyy',
+        typeUnion: {
+          field_a: 'a',
+          field_b: 'b'
+        }
+      }
+    });
+  });
+
+  it('should return error when request would match two different schemas with same amount of properties', async () => {
+    const actual = await axios.post(
+      '/item',
+      JSON.stringify({
+        requiredField: 'xxx',
+        optionalField: 'yyy',
+        typeUnion: {
+          field_a: 'a',
+          unknownField: true
+        }
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    expect(actual.status).toBe(500);
+  });
 });


### PR DESCRIPTION
This wouldn't be backwards compatible change as now we are loosening validation with "drop". 

Earlier we would have thrown an error (which some clients might be depending at the moment, hopefully not) if input matched multiple schemas with "drop" option. Now the behaviour would change to first check which object had the most matched properties and use it.

If multiple matched objects has the same amount of matched properties, we can't identify the best match and return the same error as earlier `multiple options match` 