### PR TITLE
Add possibility drop additional properties when client is handling response from server

### DIFF
--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -155,9 +155,10 @@ export interface OpTree<T> {
 function makeParam(
   adapter: ClientAdapter,
   param: { name: string; tree: OpTree<server.Handler> },
-  pathParams: string[]
+  pathParams: string[],
+  opts: server.HandlerOptions | undefined
 ) {
-  return (value: string) => fromTree(adapter, param.tree, [...pathParams, value]);
+  return (value: string) => fromTree(adapter, param.tree, [...pathParams, value], opts);
 }
 
 function paramObject(pathParams: string[], path: string) {
@@ -214,9 +215,9 @@ function fromTree(
   adapter: ClientAdapter,
   tree: OpTree<server.Handler>,
   pathParams: string[],
-  opts?: server.HandlerOptions
+  opts: server.HandlerOptions | undefined
 ): ClientSpec {
-  const node: any = tree.param ? makeParam(adapter, tree.param, pathParams) : {};
+  const node: any = tree.param ? makeParam(adapter, tree.param, pathParams, opts) : {};
   Object.keys(tree.methods).forEach(key => {
     assert(!node[key], 'duplicate path part ' + key);
     node[key] = makeMethod(adapter, tree.methods[key], pathParams, opts);

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -210,7 +210,9 @@ export function safe<
       ),
       requestContext: ctx.requestContext as any
     });
-    const responseValue = response(result, { convertFromNetwork: mode === 'client' }).success(
+    const isClientMode = mode === 'client';
+    const responseMakeOptions = isClientMode ? validationOptions.body : {};
+    const responseValue = response(result, { ...responseMakeOptions, convertFromNetwork: isClientMode }).success(
       throwResponseValidationError.bind(null, `body ${ctx.path}`, result.value.value)
     );
     if (mode === 'client' || !responseValue) {

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -212,9 +212,10 @@ export function safe<
     });
     const isClientMode = mode === 'client';
     const responseMakeOptions = isClientMode ? validationOptions.body : {};
-    const responseValue = response(result, { ...responseMakeOptions, convertFromNetwork: isClientMode }).success(
-      throwResponseValidationError.bind(null, `body ${ctx.path}`, result.value.value)
-    );
+    const responseValue = response(result, {
+      ...responseMakeOptions,
+      convertFromNetwork: isClientMode
+    }).success(throwResponseValidationError.bind(null, `body ${ctx.path}`, result.value.value));
     if (mode === 'client' || !responseValue) {
       return responseValue;
     }

--- a/test/request-parsing/api-out-of-sync.yml
+++ b/test/request-parsing/api-out-of-sync.yml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: example service
+servers:
+  - url: http://localhost:12000
+paths:
+  /item:
+    get:
+      description: get an item
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  existingField:
+                    type: string
+                required:
+                  - existingField
+

--- a/test/request-parsing/api.yml
+++ b/test/request-parsing/api.yml
@@ -51,3 +51,21 @@ paths:
             application/json:
               schema:
                 type: object
+    get:
+      description: get an item
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  existingField:
+                    type: string
+                  newField:
+                    type: string
+                required:
+                  - existingField
+

--- a/test/request-parsing/client-body-send.spec.ts
+++ b/test/request-parsing/client-body-send.spec.ts
@@ -1,18 +1,19 @@
 // yarn ts-node examples/server.ts
 import { describe, it, expect, beforeAll } from '@jest/globals';
 import * as server from './tmp/server/generated';
+import * as client from './tmp/client/generated';
 import * as runtime from '@smartlyio/oats-runtime';
 import * as koaAdapter from '@smartlyio/oats-koa-adapter';
 import * as Koa from 'koa';
 import { koaBody } from 'koa-body';
+import * as axiosAdapter from '@smartlyio/oats-axios-adapter';
 import * as http from 'http';
 import { AddressInfo } from 'net';
-import { Axios } from 'axios';
 
-describe('server body', () => {
+describe('client body send', () => {
   const getRoutes = () =>
     koaAdapter.bind(
-      server.createRouter({ validationOptions: { body: { unknownField: 'drop' } } }),
+      server.createRouter({ validationOptions: { body: { unknownField: 'fail' } } }),
       {
         '/item': {
           post: async ctx => {
@@ -39,44 +40,41 @@ describe('server body', () => {
       const server = createApp().listen(0, () => resolve(server));
     });
     const { port } = httpServer.address() as AddressInfo;
-    const axios = new Axios({
-      baseURL: `http://localhost:${port}`
+    const clientSpec = client.createClient({
+      validationOptions: { body: { unknownField: 'drop' } }
+    })(spec => {
+      return axiosAdapter.create()({ ...spec, servers: [`http://localhost:${port}`] });
     });
     return {
       httpServer,
-      axios
+      clientSpec
     };
   };
 
   let httpServer: http.Server;
-  let axios: Axios;
+  let clientSpec: client.ClientSpec;
   beforeAll(async () => {
     const response = await createServer();
     httpServer = response.httpServer;
-    axios = response.axios;
+    clientSpec = response.clientSpec;
   });
 
   afterAll(() => {
     httpServer?.close();
   });
 
-  it('should drop all unknown values and process request when dropping unknown fields', async () => {
-    const actual = await axios.post(
-      '/item',
-      JSON.stringify({
-        thisIsUnkownProperty: 'value',
-        requiredField: 'xxx',
-        optionalField: 'yyy'
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }
-    );
+  it('should drop all unknown values before sending request to server when dropping unknown fields', async () => {
+    const body = {
+      thisIsUnkownProperty: 'value',
+      requiredField: 'xxx',
+      optionalField: 'yyy'
+    } as any;
+    const actual = await clientSpec.item.post({
+      body: runtime.client.json(body)
+    });
 
     expect(actual.status).toBe(200);
-    expect(JSON.parse(actual.data)).toEqual({
+    expect(actual.value.value).toEqual({
       body: {
         requiredField: 'xxx',
         optionalField: 'yyy'
@@ -85,29 +83,25 @@ describe('server body', () => {
   });
 
   it('should drop unknown fields and match to closest schema', async () => {
-    const actual = await axios.post(
-      '/item',
-      JSON.stringify({
-        requiredField: 'xxx',
-        optionalField: 'yyy',
-        typeUnion: {
-          field_a: 'a',
-          field_b: 'b',
-          unknownField: true
-        }
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    const body = {
+      requiredField: 'yyy',
+      optionalField: 'xxx',
+      typeUnion: {
+        field_a: 'a',
+        field_b: 'b',
+        unknownField: true
       }
-    );
+    } as any;
+
+    const actual = await clientSpec.item.post({
+      body: runtime.client.json(body)
+    });
 
     expect(actual.status).toBe(200);
-    expect(JSON.parse(actual.data)).toEqual({
+    expect(actual.value.value).toEqual({
       body: {
-        requiredField: 'xxx',
-        optionalField: 'yyy',
+        requiredField: 'yyy',
+        optionalField: 'xxx',
         typeUnion: {
           field_a: 'a',
           field_b: 'b'
@@ -116,24 +110,20 @@ describe('server body', () => {
     });
   });
 
-  it('should return error when request would match two different schemas with same amount of properties', async () => {
-    const actual = await axios.post(
-      '/item',
-      JSON.stringify({
-        requiredField: 'xxx',
-        optionalField: 'yyy',
-        typeUnion: {
-          field_a: 'a',
-          unknownField: true
-        }
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+  it('should throw error when object would match two different schemas with same amount of properties', async () => {
+    const body = {
+      requiredField: 'yyy',
+      optionalField: 'xxx',
+      typeUnion: {
+        field_a: 'a',
+        unknownField: true
       }
-    );
+    } as any;
 
-    expect(actual.status).toBe(500);
+    await expect(() =>
+      clientSpec.item.post({
+        body: runtime.client.json(body)
+      })
+    ).rejects.toThrow(/typeUnion: multiple options match/);
   });
 });

--- a/test/request-parsing/driver.ts
+++ b/test/request-parsing/driver.ts
@@ -11,6 +11,14 @@ driver.generate({
 });
 
 driver.generate({
+  generatedValueClassFile: './tmp/client-out-of-sync/types.generated.ts',
+  generatedClientFile: './tmp/client-out-of-sync/generated.ts',
+  header: '/* tslint:disable variable-name only-arrow-functions*/',
+  openapiFilePath: './api-out-of-sync.yml',
+  resolve: driver.compose(driver.generateFile(), driver.localResolve)
+});
+
+driver.generate({
   generatedValueClassFile: './tmp/server/types.generated.ts',
   generatedServerFile: './tmp/server/generated.ts',
   header: '/* tslint:disable variable-name only-arrow-functions*/',


### PR DESCRIPTION
Currently client can't drop additional properties even though client is created with:
```ts
client.createClient({
      validationOptions: { body: { unknownField: 'drop' } }
    })
```

Lets fix that, and let client also drop additional properties from server responses.

This currently works for:
* client sending request
* server receiving request

but was missing from client receiving response from the server. 