### PR TITLE
Dont try to parse a body if there isn't one

### DIFF
--- a/packages/oats-fetch-adapter/index.ts
+++ b/packages/oats-fetch-adapter/index.ts
@@ -39,10 +39,8 @@ function getContentType(response: Response) {
 }
 
 function getResponseData(contentType: string, response: Response) {
-  if (contentType === runtime.noContentContentType) {
-    if (!response.body) {
-      return null;
-    }
+  if (contentType === runtime.noContentContentType || !response.body) {
+    return null;
   }
   if (response.status === 204) {
     return '';


### PR DESCRIPTION
fetch doesn't return a body on `HEAD` calls. and overall we shouldn't try to parse one if there isn't one to parse 🤷 