### PR TITLE
fix incorrect network mapping when values are made more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+#
+
+Bug fix for network mapping when a value was made with different makers. 
+
+```
+   const value = Amake(input).success();
+   const value2 = Bmake(value).success();
+```
+
+value2 had both A and B types and network mapping tried to use mapping also from A type when it should have only used mappings from type B if any.
+Now value2 does not have a linkage anymore to type A and will not be considered when network mapping. 
+
+Note: because value2 does not have type A anymore any `getType` or `getTypeSet` reflection calls will return different
+results to what was previously returned.
+
+There may be a performance downside to this as we might end up doing extra work as we lose the type information. 
+Even without doing double `.make` by hand allOf parsing may result in more work being done as we clear the extra type information before parsing.
+
 # 6.2.0
 
 Bug fix that changes aliasing of objects returned by Oats. Now re-making an object with the same maker will return the

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -261,7 +261,7 @@ function checkAny(value: any, opts?: MakeOptions) {
   if (opts?.mergeTypes && type && type.length > 0) {
     return Make.ok(value);
   }
-  return Make.ok(_.cloneDeep(value));
+  return Make.ok(structuredClone(value));
 }
 
 export function makeAny() {

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -256,12 +256,28 @@ function makeFloatOrInteger(
   };
 }
 
+function cloneWithoutTypes(value: unknown): any {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneWithoutTypes(item));
+  }
+  if (value && typeof value === 'object') {
+    const types = getTypeSet(value);
+    if (types && types.size > 0) {
+      return Object.entries(value).reduce<Record<string, any>>((memo, [prop, value]) => {
+        memo[prop] = cloneWithoutTypes(value);
+        return memo;
+      }, {});
+    }
+  }
+  return value;
+}
+
 function checkAny(value: any, opts?: MakeOptions) {
   const type = getType(value);
   if (opts?.mergeTypes && type && type.length > 0) {
     return Make.ok(value);
   }
-  return Make.ok(structuredClone(value));
+  return Make.ok(cloneWithoutTypes(value));
 }
 
 export function makeAny() {

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -5,6 +5,7 @@ import * as classWithAdditional from './test-class-with-additional-props';
 import { Type } from '../src/reflection-type';
 import { serialize } from '../src/serialize';
 import { getType, withType } from '../src/type-tag';
+import { File, FormBinary } from '../src/make';
 
 describe('union differentation', () => {
   it('handles cases where union children are missing the tag', () => {
@@ -407,6 +408,30 @@ describe('unknown', () => {
     const item = new TestClass({ a: ['a'], b: 'b' });
     expect(fun(item).success()).toEqual(item);
     expect(fun(item).success() !== item).toBeTruthy();
+  });
+  it('keeps Buffer instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = Buffer.alloc(1, 'x', 'utf-8');
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
+  });
+  it('keeps File instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new File('path', 10, 'name');
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
+  });
+  it('keeps FormBinary instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new FormBinary({ binary: Buffer.alloc(1, 'x', 'utf-8') });
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
+  });
+  it('keeps FormBinary instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new FormBinary({ binary: Buffer.alloc(1, 'x', 'utf-8') });
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
   });
   it('keeps custom instances', async () => {
     const fun = make.fromReflection({ type: 'unknown' });

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -398,7 +398,22 @@ describe('intersection', () => {
   });
 });
 
+class SomeClass {
+  a: 1;
+}
 describe('unknown', () => {
+  it('redoes value classes', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new TestClass({ a: ['a'], b: 'b' });
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() !== item).toBeTruthy();
+  });
+  it('keeps custom instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new SomeClass();
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
+  });
   it('keeps instances', async () => {
     const fun = make.fromReflection({ type: 'unknown' });
     const item = new Date();

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -400,7 +400,7 @@ describe('intersection', () => {
 });
 
 class SomeClass {
-  a: 1;
+  a = 1;
 }
 describe('unknown', () => {
   it('redoes value classes', async () => {

--- a/packages/oats-runtime/test/make-from-reflection.spec.ts
+++ b/packages/oats-runtime/test/make-from-reflection.spec.ts
@@ -4,7 +4,7 @@ import { TestClass } from './test-class';
 import * as classWithAdditional from './test-class-with-additional-props';
 import { Type } from '../src/reflection-type';
 import { serialize } from '../src/serialize';
-import { getType } from '../src/type-tag';
+import { getType, withType } from '../src/type-tag';
 
 describe('union differentation', () => {
   it('handles cases where union children are missing the tag', () => {
@@ -399,12 +399,32 @@ describe('intersection', () => {
 });
 
 describe('unknown', () => {
+  it('keeps instances', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = new Date();
+    expect(fun(item).success()).toEqual(item);
+    expect(fun(item).success() === item).toBeTruthy();
+  });
+
+  it('loses deep reflection types', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = [{ prop: withType({}, [{ type: 'boolean' }]) }];
+    expect(item[0].prop).not.toEqual(undefined);
+    expect(fun(item).success()).toEqual(item);
+    expect(getType(fun(item[0].prop))).toEqual(undefined);
+  });
+
+  it('loses reflection types', async () => {
+    const fun = make.fromReflection({ type: 'unknown' });
+    const item = withType({}, [{ type: 'boolean' }]);
+    expect(item).not.toEqual(undefined);
+    expect(fun(item).success()).toEqual(item);
+    expect(getType(fun(item))).toEqual(undefined);
+  });
+
   jsc.property('allows anything', jsc.json, async item => {
     const fun = make.fromReflection({ type: 'unknown' });
     expect(fun(item).success()).toEqual(item);
-    if (item && typeof item === 'object') {
-      expect(fun(item).success() !== item).toBeTruthy();
-    }
     return true;
   });
 });

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -153,6 +153,22 @@ components:
           properties:
             prop:
               $ref: "#/components/schemas/NestedNamed"
+    allOfWithAny:
+      allOf:
+        - $ref: "#/components/schemas/ObjectWithSpecifiedField"
+        - $ref: "#/components/schemas/ObjectWithAnyField"
+    ObjectWithAnyField:
+      type: object
+      properties:
+        field: {}
+    ObjectWithSpecifiedField:
+      type: object
+      properties:
+        field:
+          type: object
+          properties:
+            foo_bar:
+              type: string
     AllOfSchema:
       allOf:
         - $ref: "#/components/schemas/Item"

--- a/test/property-name-mapping/api.yml
+++ b/test/property-name-mapping/api.yml
@@ -161,6 +161,16 @@ components:
       type: object
       properties:
         field: {}
+    NamedField:
+      type: object
+      properties:
+        foo_bar:
+          type: string
+    ObjectWithNamedField:
+      type: object
+      properties:
+        field:
+          $ref: '#/components/schemas/NamedField'
     ObjectWithSpecifiedField:
       type: object
       properties:

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -102,6 +102,17 @@ describe('network ts mapping', () => {
       const serialized = runtime.serialize(value);
       expect(serialized).toEqual(input);
     });
+    it('forgets about mapping from previous make', () => {
+      const previousValue = types.typeObjectWithSpecifiedField
+        .maker({ field: { fooBar: 'a' } })
+        .success();
+      const value = types.typeObjectWithAnyField.maker(previousValue).success();
+      expect(runtime.serialize(value)).toEqual({ field: { fooBar: 'a' } });
+    });
+    it('remembers mapping within allOf', () => {
+      const value = types.typeAllOfWithAny.maker({ field: { fooBar: 'a' } }).success();
+      expect(runtime.serialize(value)).toEqual({ field: { foo_bar: 'a' } });
+    });
     it('maps props in nested objects', () => {
       const input = {
         prop: {

--- a/test/property-name-mapping/property-name-mapper.spec.ts
+++ b/test/property-name-mapping/property-name-mapper.spec.ts
@@ -102,6 +102,13 @@ describe('network ts mapping', () => {
       const serialized = runtime.serialize(value);
       expect(serialized).toEqual(input);
     });
+    it('forgets about mapping from previous make with nested objects', () => {
+      const previousValue = types.typeObjectWithNamedField
+        .maker({ field: { fooBar: 'a' } })
+        .success();
+      const value = types.typeObjectWithAnyField.maker(previousValue).success();
+      expect(runtime.serialize(value)).toEqual({ field: { fooBar: 'a' } });
+    });
     it('forgets about mapping from previous make', () => {
       const previousValue = types.typeObjectWithSpecifiedField
         .maker({ field: { fooBar: 'a' } })


### PR DESCRIPTION
Bug fix for network mapping when a value was made with different makers. 

```
   const value = Amake(input).success();
   const value2 = Bmake(value).success();
```

value2 had both A and B types and network mapping tried to use mapping also from A type when it should have only used mappings from type B if any.
Now value2 does not have a linkage anymore to type A and will not be considered when network mapping. 

Note: because value2 does not have type A anymore any `getType` or `getTypeSet` reflection calls will return different
results to what was previously returned.

There may be a performance downside to this as we might end up doing extra work as we lose the type information. 
Even without doing double `.make` by hand allOf parsing may result in more work being done as we clear the extra type information before parsing.