### PR TITLE
Support abort signal

### DIFF
--- a/packages/oats-axios-adapter/index.ts
+++ b/packages/oats-axios-adapter/index.ts
@@ -101,6 +101,7 @@ function createAxiosAdapter({
       params,
       paramsSerializer: preserveQueryArrayParamNames ? urlSearchParamsSerializer : undefined,
       data,
+      signal: arg.signal,
       validateStatus: () => true
     });
     const contentType = getContentType(response);

--- a/packages/oats-fetch-adapter/index.ts
+++ b/packages/oats-fetch-adapter/index.ts
@@ -81,6 +81,7 @@ export function create(init?: RequestInit): runtime.client.ClientAdapter {
           ...(requestContentType ? { 'content-type': requestContentType } : {}),
           ...arg.headers
         },
+        signal: arg.signal,
         body: data
       })
     );

--- a/packages/oats-runtime/src/client.ts
+++ b/packages/oats-runtime/src/client.ts
@@ -11,7 +11,9 @@ export type ClientArg<
   H extends server.Headers | void,
   Q extends server.Query | void,
   B extends server.RequestBody<any> | void
-> = MakeOptional<H, 'headers'> & MakeOptional<Q, 'query'> & MakeOptional<B, 'body'>;
+> = MakeOptional<H, 'headers'> &
+  MakeOptional<Q, 'query'> &
+  MakeOptional<B, 'body'> & { readonly signal?: AbortSignal };
 
 export type ClientEndpoint<
   H extends server.Headers | void,
@@ -207,6 +209,7 @@ function makeMethod(
       headers: ctx?.headers,
       query: ctx?.query,
       body: ctx?.body,
+      signal: ctx?.signal,
       requestContext: { path: handler.path }
     });
 }

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -53,7 +53,7 @@ export type ServerEndpointArg<
   Q extends Query | void,
   Body extends RequestBody<any> | void,
   RC extends RequestContext
-> = EndpointArg<H, P, Q, Body> & { readonly requestContext: RC };
+> = EndpointArg<H, P, Q, Body> & { readonly requestContext: RC; readonly signal?: AbortSignal };
 
 export type Endpoint<
   H extends Headers | void,

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -45,6 +45,7 @@ export interface EndpointArg<
   params: P;
   query: Q;
   body: Body;
+  signal?: AbortSignal;
 }
 
 export type ServerEndpointArg<
@@ -210,6 +211,7 @@ export function safe<
           throwRequestValidationError.bind(null, 'body')
         )
       ),
+      signal: ctx.signal,
       requestContext: ctx.requestContext as any
     });
     const isClientMode = mode === 'client';

--- a/packages/oats-runtime/test/client.spec.ts
+++ b/packages/oats-runtime/test/client.spec.ts
@@ -102,4 +102,10 @@ describe('ClientEndpoint', () => {
       query: { a: 'foo' }
     });
   });
+
+  it('allows passing CancelSignal', () => {
+    void mock<client.ClientEndpoint<void, { a?: string }, void, typeof response>>()({
+      signal: new AbortController().signal
+    });
+  });
 });

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -82,6 +82,16 @@ describe('fetch adapter', () => {
     expect(receivedContext.body).toEqual(null);
   });
 
+  it('aborts signal', async () => {
+    const abort = new AbortController();
+    setTimeout(() => abort.abort(), 1);
+    await expect(apiClient.get({ signal: abort.signal })).rejects.toThrow(
+      'This operation was aborted'
+    );
+
+    expect(abort.signal.aborted).toBeTruthy();
+  });
+
   it('correctly calls GET request with query parameters', async () => {
     const response = await apiClient['with-query'].get({
       query: { one: 'the loneliest number' }

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -14,7 +14,9 @@ describe('fetch adapter', () => {
   let receivedContext: any;
   let callback: (...args: any[]) => Promise<void>;
   beforeEach(() => {
-    callback = async () => { return };
+    callback = async () => {
+      return;
+    };
   });
 
   const spec: server.Endpoints = Object.fromEntries(

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -7,6 +7,7 @@ import * as Koa from 'koa';
 import { koaBody } from 'koa-body';
 import * as fetchAdapter from '@smartlyio/oats-fetch-adapter';
 import * as http from 'http';
+import { setTimeout } from 'timers/promises';
 
 describe('fetch adapter', () => {
   let apiClient: client.ClientSpec;
@@ -19,6 +20,7 @@ describe('fetch adapter', () => {
       {
         [handler.method]: async (ctx: any) => {
           receivedContext = ctx;
+          await setTimeout(100);
           return runtime.text(200, 'done');
         }
       }
@@ -84,12 +86,9 @@ describe('fetch adapter', () => {
 
   it('aborts signal', async () => {
     const abort = new AbortController();
-    setTimeout(() => abort.abort(), 1);
-    await expect(apiClient.get({ signal: abort.signal })).rejects.toThrow(
-      'This operation was aborted'
-    );
-
-    expect(abort.signal.aborted).toBeTruthy();
+    const promise = apiClient.get({ signal: abort.signal });
+    abort.abort();
+    await expect(promise).rejects.toThrow('This operation was aborted');
   });
 
   it('correctly calls GET request with query parameters', async () => {


### PR DESCRIPTION
**What?**
Allow passing `AbortController.signal` to oats axios / fetch adapters.