### PR TITLE
Update oats-axios-adapter peer dependencies

### DIFF
--- a/packages/oats-axios-adapter/package.json
+++ b/packages/oats-axios-adapter/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^6.0.0",
+    "@smartlyio/oats-runtime": "^7.0.0",
     "axios": "^0.27.0 || ^1.0.0",
     "typescript": "^4.8.0 || ^5.0.0"
   },


### PR DESCRIPTION
Allow latest version of oats-runtime for oats-axios-adapter.