### PR TITLE
Handle noContentType correctly for fetch adapter

### DIFF
--- a/packages/oats-fetch-adapter/index.ts
+++ b/packages/oats-fetch-adapter/index.ts
@@ -29,7 +29,7 @@ function toRequestData(data: runtime.server.RequestBody<any> | undefined) {
 
 function getContentType(response: Response) {
   const type = response.headers.get('content-type');
-  if (!type) {
+  if (!type || type === runtime.noContentContentType) {
     return runtime.noContentContentType;
   }
   if (response.status === 204) {

--- a/test/fetch-adapter/api.yml
+++ b/test/fetch-adapter/api.yml
@@ -92,3 +92,21 @@ paths:
             text/plain:
               schema:
                 type: string
+  /with-no-content:
+    patch:
+      description: endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        204:
+          description: endpoint
+        500:
+          description: endpoint
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -207,7 +207,7 @@ describe('fetch adapter', () => {
     expect(receivedContext.headers).toEqual(null);
     expect(receivedContext.body).toEqual({
       contentType: runtime.noContentContentType,
-      value: { one: 'the loneliest number' }
+      value: null
     });
   });
 });

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -193,7 +193,7 @@ describe('fetch adapter', () => {
       status: 204,
       body: {
         contentType: runtime.noContentContentType,
-        value: { one: 'the loneliest number' }
+        value: null
       }
     });
 

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -26,6 +26,11 @@ describe('fetch adapter', () => {
         [handler.method]: async (ctx: any) => {
           receivedContext = ctx;
           await callback(ctx);
+
+          if (handler.path === '/with-no-content') {
+            return runtime.noContent(204);
+          }
+
           return runtime.text(200, 'done');
         }
       }
@@ -188,26 +193,25 @@ describe('fetch adapter', () => {
     });
   });
 
-  it('correctly calls PATCH(or any) request with noContentType', async () => {
-    const response = await apiClient['with-patch'].patch({
-      status: 204,
+  it('correctly calls PATCH(or any) request with noContentType content-type response', async () => {
+    const response = await apiClient['with-no-content'].patch({
       body: {
-        contentType: runtime.noContentContentType,
-        value: null
+        contentType: 'application/json',
+        value: { one: 'the loneliest number' }
       }
     });
 
     expect(response.status).toBe(204);
     expect(response.value.contentType).toBe(runtime.noContentContentType);
-    expect(response.value.value).toBe('done');
+    expect(response.value.value).toBe(null);
 
     expect(receivedContext).toBeDefined();
     expect(receivedContext.method).toEqual('patch');
-    expect(receivedContext.path).toEqual('/with-patch');
+    expect(receivedContext.path).toEqual('/with-no-content');
     expect(receivedContext.headers).toEqual(null);
     expect(receivedContext.body).toEqual({
-      contentType: runtime.noContentContentType,
-      value: null
+      contentType: 'application/json',
+      value: { one: 'the loneliest number' }
     });
   });
 });

--- a/test/fetch-adapter/fetch-adapter.spec.ts
+++ b/test/fetch-adapter/fetch-adapter.spec.ts
@@ -187,4 +187,27 @@ describe('fetch adapter', () => {
       value: { one: 'the loneliest number' }
     });
   });
+
+  it('correctly calls PATCH(or any) request with noContentType', async () => {
+    const response = await apiClient['with-patch'].patch({
+      status: 204,
+      body: {
+        contentType: runtime.noContentContentType,
+        value: { one: 'the loneliest number' }
+      }
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.value.contentType).toBe(runtime.noContentContentType);
+    expect(response.value.value).toBe('done');
+
+    expect(receivedContext).toBeDefined();
+    expect(receivedContext.method).toEqual('patch');
+    expect(receivedContext.path).toEqual('/with-patch');
+    expect(receivedContext.headers).toEqual(null);
+    expect(receivedContext.body).toEqual({
+      contentType: runtime.noContentContentType,
+      value: { one: 'the loneliest number' }
+    });
+  });
 });


### PR DESCRIPTION
Now we have an issue with oats-fetch-adapter, that the runtime validation fails for the response with the error like: 
```
invalid response body /workspaces/{workspaceId} no option of oneOf matched - option 1 value: no option of oneOf matched - option 1 value: expected value to be one of , but got "" instead.
```

I am not sure how to test the implementation locally, but I believe based on the logic that it happens because:
1. The content type identifies incorrectly here: https://github.com/smartlyio/oats/blob/master/packages/oats-fetch-adapter/index.ts#L36
2. The response returns incorrectly here as ""(empty string) instead of `null` https://github.com/smartlyio/oats/blob/master/packages/oats-fetch-adapter/index.ts#L45

I faced the problem in this PR for frontend https://github.com/smartlyio/frontend/pull/24910
