### PR TITLE
Add name field to runtime error subclasses

### DIFF
--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -7,6 +7,7 @@ import { discriminateUnion } from './union-discriminator';
 import { getType, getTypeSet, withType } from './type-tag';
 
 export class MakeError extends Error {
+  readonly name = 'MakeError';
   constructor(readonly errors: ValidationError[]) {
     super(
       'tried to get success value from error: ' + errors.map(validationErrorPrinter).join('\n')

--- a/packages/oats-runtime/src/server.ts
+++ b/packages/oats-runtime/src/server.ts
@@ -89,12 +89,14 @@ export interface Endpoints {
 }
 
 export class RequestValidationError extends Error {
+  readonly name = 'RequestValidationError';
   constructor(public tag: string, public errors: ValidationError[]) {
     super('invalid request ' + tag + ' ' + errors.map(validationErrorPrinter).join('\n'));
   }
 }
 
 export class ResponseValidationError extends Error {
+  readonly name = 'ResponseValidationError';
   constructor(public tag: string, public originalResponse: any, public errors: ValidationError[]) {
     super('invalid response ' + tag + ' ' + errors.map(validationErrorPrinter).join('\n'));
   }


### PR DESCRIPTION
Helps distinguish OpenAPI errors in logs, Sentry, and other places that rely on the name property. 

Because there was no custom name in the first place, I don't expect any client code to rely on it.