### PR TITLE
Make import resolve logging optional

### DIFF
--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -1,3 +1,4 @@
+import { debuglog } from 'node:util';
 import * as oas from 'openapi3-ts';
 import * as ts from 'typescript';
 import * as _ from 'lodash';
@@ -7,6 +8,8 @@ import { NameKind, UnsupportedFeatureBehaviour } from './util';
 import * as path from 'path';
 import { resolvedStatusCodes } from './status-codes';
 import { buildMethod } from './builder';
+
+const info = debuglog('oats');
 
 const valueClassIndexSignatureKey = 'instanceIndexSignatureKey';
 const scalarTypes = ['string', 'integer', 'number', 'boolean'];
@@ -57,11 +60,6 @@ export interface Options {
    * */
   propertyNameMapper?: (openapiPropertyName: string) => string;
   nameMapper: oautil.NameMapper;
-}
-
-export function info(message: string) {
-  // eslint-disable-next-line no-console
-  console.log('info: ' + message);
 }
 
 export function deprecated(condition: any, message: string) {


### PR DESCRIPTION
Extremely minor, but also extremely annoying, generator output is filled with import resolve logging, which is not needed every time you generate stuff.

With this PR, these messages will be hidden by default, but could be enabled back with `NODE_DEBUG=oats`. This is a simple and standard way to handle these things in node

Before
![CleanShot 2024-01-26 at 14 54 29@2x](https://github.com/smartlyio/oats/assets/464357/21584b42-a788-4fc7-a784-515e496b3234)

After
![CleanShot 2024-01-26 at 15 21 08@2x](https://github.com/smartlyio/oats/assets/464357/7ae2e9eb-96da-42d3-86e5-f4fe057640ba)
