### PR TITLE
Support relative servers in fetch adapter in the browser

### DIFF
--- a/packages/oats-fetch-adapter/index.ts
+++ b/packages/oats-fetch-adapter/index.ts
@@ -62,7 +62,7 @@ export function create(init?: RequestInit): runtime.client.ClientAdapter {
     }
     const server = arg.servers[0];
     const data = toRequestData(arg.body);
-    const url = new URL(server + arg.path);
+    const url = new URL(server + arg.path, globalThis.location?.origin);
     const requestContentType = arg.body?.contentType;
 
     Object.entries(arg.query ?? {})


### PR DESCRIPTION
Currently, every fetch-based browser client prepends the location.origin to the already-specified relative path in the server definition, it's pure boilerplate. E.g. you can delete the `servers` prop from 
```
adapter.create()({
    ...spec,
    headers,
    servers: [`https://${window.location.host}/mosby`],
  })
```  
(people who put `http://localhost:9000/goya` into their servers field will continue enjoying their servers array overrides)


With this PR, fetch adapter will do the reasonable thing and use page origin if the no origin is provided. I.e. it modifies behavior only for a case when an error was thrown before, it will not override explicitly provided origins

No tests, as I'd be testing jsdom setup and built-in classes mostly, and I didn't want to add a whole new test adapter just for this.