### PR TITLE
Fix `data.getHeaders is not a function` issue

### DIFF
--- a/packages/oats-axios-adapter/index.ts
+++ b/packages/oats-axios-adapter/index.ts
@@ -92,7 +92,7 @@ function createAxiosAdapter({
     const url = server + arg.path;
     const headers = removeUndefined({
       ...arg.headers,
-      ...(data instanceof FormData ? data.getHeaders() : {})
+      ...(data instanceof FormData && data.getHeaders ? data.getHeaders() : {})
     });
     const response = await axiosInstance.request({
       method: arg.method,


### PR DESCRIPTION
<img width="756" alt="Screenshot 2024-04-05 at 2 02 36 PM" src="https://github.com/smartlyio/oats/assets/122093405/24976b5b-7aac-4388-a3a4-2c098f72c909">

[form-data](https://www.npmjs.com/package/form-data) is used only on Node. if its run on the browser, it will switch to the window's version of FormData. Library code:
`module.exports = typeof self == 'object' ? self.FormData : window.FormData`

For that reason we are getting the above error while making a `multipart/form-data` type request.