### PR TITLE
nullable first

### DIFF
--- a/packages/oats/src/generate-types.ts
+++ b/packages/oats/src/generate-types.ts
@@ -524,6 +524,14 @@ export function run(options: Options) {
         : typeMapper(resolved.member);
       return ts.factory.createTypeReferenceNode(type, undefined);
     }
+
+    if (schema.nullable) {
+      return ts.factory.createUnionTypeNode([
+        generateType({ ...schema, nullable: false }, typeMapper),
+        ts.factory.createLiteralTypeNode(ts.factory.createNull())
+      ]);
+    }
+
     if (schema.oneOf) {
       return ts.factory.createUnionTypeNode(
         schema.oneOf.map(schema => generateType(schema, typeMapper))
@@ -537,13 +545,6 @@ export function run(options: Options) {
     }
 
     assert(!schema.anyOf, 'anyOf is not supported');
-
-    if (schema.nullable) {
-      return ts.factory.createUnionTypeNode([
-        generateType({ ...schema, nullable: false }, typeMapper),
-        ts.factory.createLiteralTypeNode(ts.factory.createNull())
-      ]);
-    }
 
     if (schema.type === 'object') {
       return ts.factory.createTypeLiteralNode(


### PR DESCRIPTION
When `nullable` is combined with `allOf` and `oneOf` the client is failing to accept null values in request body (at least) and types are also not allowing null values.