### PR TITLE
import Buffer from buffer

### DIFF
--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -26,6 +26,7 @@
     "@smartlyio/safe-navigation": "^5.1.0",
     "@types/encodeurl": "1.0.0",
     "@types/escape-html": "1.0.2",
+    "buffer": "6.0.3",
     "encodeurl": "1.0.2",
     "escape-html": "1.0.3",
     "lodash": "^4.17.20"

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -12,7 +12,8 @@
     "clean:dist": "rm -rf ./dist",
     "prebuild": "yarn clean && yarn tsc --project tsconfig.test.json --noEmit",
     "build": "yarn tsc",
-    "postbuild": "sed -i bak 1d dist/make.d.ts && rm dist/make.d.tsbak",
+    "postbuild": "yarn remove-references",
+    "remove-references": "cat dist/make.d.ts > dist/make.d.tsbak && sed 's/\\/\\/\\/.*//g' > dist/make.d.ts < dist/make.d.tsbak && rm dist/make.d.tsbak",
     "lint": "eslint --max-warnings=0 --ext .ts src test",
     "lint:fix": "eslint --max-warnings=0 --ext .ts src test --fix"
   },

--- a/packages/oats-runtime/package.json
+++ b/packages/oats-runtime/package.json
@@ -12,6 +12,7 @@
     "clean:dist": "rm -rf ./dist",
     "prebuild": "yarn clean && yarn tsc --project tsconfig.test.json --noEmit",
     "build": "yarn tsc",
+    "postbuild": "sed -i bak 1d dist/make.d.ts && rm dist/make.d.tsbak",
     "lint": "eslint --max-warnings=0 --ext .ts src test",
     "lint:fix": "eslint --max-warnings=0 --ext .ts src test --fix"
   },

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -1,4 +1,5 @@
 import { assert, fail } from './assert';
+// eslint-disable-next-line import/no-nodejs-modules
 import { Buffer } from 'buffer';
 import * as _ from 'lodash';
 import { isEqual, uniq } from 'lodash';

--- a/packages/oats-runtime/src/make.ts
+++ b/packages/oats-runtime/src/make.ts
@@ -1,4 +1,5 @@
 import { assert, fail } from './assert';
+import { Buffer } from 'buffer';
 import * as _ from 'lodash';
 import { isEqual, uniq } from 'lodash';
 import { ValueClass } from './value-class';


### PR DESCRIPTION
Buffer is node specific api which causes trouble when trying to use oats-runtime in browser. 

 * use feross/buffer which has separate entrypoints for node (using node Buffer) and browser (using a lookalike)
 * remove the typescript reference from make.d.ts that includes node types

canary release @7.5.1-alpha.11