### PR TITLE
includeEndpoints-driver-option

### DIFF
--- a/packages/oats/src/driver.ts
+++ b/packages/oats/src/driver.ts
@@ -50,6 +50,13 @@ export interface Driver {
   generatedClientFile?: string;
   runtimeFilePath?: string; // set path to runtime directly for testing
   emitStatusCode?: (statusCode: number) => boolean;
+  /**
+   * Generate types, client or server only for the provided endpoints.
+   * @example
+   * includeEndpoints: {
+   *   '/user/{user_id}': ['GET', 'PUT']
+   * }
+   */
   includeEndpoints?: Record<string, Uppercase<serverRuntime.Methods>[]>;
   unsupportedFeatures?: {
     security?: UnsupportedFeatureBehaviour;
@@ -180,7 +187,7 @@ export function generateFile(opts?: GenerateFileOptions): types.Resolve {
 
 export function generate(driver: Driver) {
   const file = fs.readFileSync(driver.openapiFilePath, 'utf8');
-  const spec = filterEndpointsInSpec(yaml.load(file) as oas.OpenAPIObject, driver.includeEndpoints);
+  const spec = filterEndpointsInSpec(yaml.load(file) as oas.OpenAPIObject, driver);
   const header = driver.header ? driver.header + '\n' : '';
 
   fs.mkdirSync(path.dirname(driver.generatedValueClassFile), { recursive: true });

--- a/packages/oats/src/util.ts
+++ b/packages/oats/src/util.ts
@@ -8,15 +8,15 @@ export type SchemaObject = oas.ReferenceObject | oas.SchemaObject;
 
 export function filterEndpointsInSpec(
   spec: oas.OpenAPIObject,
-  includeEndpoints: Driver['includeEndpoints']
+  { includeEndpoints }: Pick<Driver, 'includeEndpoints'>
 ): oas.OpenAPIObject {
   if (includeEndpoints === undefined) {
     return spec;
   }
-  const { paths, ...restSpec } = spec;
+  const { paths: specPaths, ...restSpec } = spec;
   const filteredPathEntries = Object.entries(includeEndpoints).flatMap(
     ([path, methodsUpperCase]): [string, oas.PathItemObject][] => {
-      const pathObject: oas.PathItemObject = spec.paths[path];
+      const pathObject: oas.PathItemObject = specPaths[path];
       const includeMethods = methodsUpperCase.map(
         method => method.toLowerCase() as Lowercase<typeof method>
       );
@@ -37,7 +37,6 @@ export function filterEndpointsInSpec(
       if (filteredPathObjectEntries.length === 0) {
         return [];
       }
-
       return [[path, Object.fromEntries(filteredPathObjectEntries)]];
     }
   );

--- a/packages/oats/src/util.ts
+++ b/packages/oats/src/util.ts
@@ -31,26 +31,23 @@ export function filterEndpointsInSpec(
   { paths: specPaths, ...restSpec }: oas.OpenAPIObject,
   includeEndpoint: IncludeEndpointFilter
 ): oas.OpenAPIObject {
-  const filteredPathEntries = Object.entries(specPaths).flatMap(
-    ([path, pathObject]: [string, oas.PathItemObject]) => {
-      const filteredPathObject: oas.PathItemObject = Object.fromEntries(
-        Object.entries(pathObject).filter(
-          ([key]) =>
-            !server.supportedMethods.includes(key as server.Methods) ||
-            includeEndpoint(path, key.toUpperCase() as Uppercase<server.Methods>)
-        )
-      );
-      const hasMethods = server.supportedMethods.some(method => filteredPathObject[method]);
-
-      if (!hasMethods) {
-        return [];
-      }
-      return [[path, filteredPathObject]] as const;
-    }
-  );
-  const filteredPaths = Object.fromEntries(filteredPathEntries);
-
-  return { ...restSpec, paths: filteredPaths };
+  return {
+    ...restSpec,
+    paths: Object.fromEntries(
+      Object.entries(specPaths)
+        .map(([path, pathObject]): [string, oas.PathItemObject] => [
+          path,
+          Object.fromEntries(
+            Object.entries(pathObject).filter(
+              ([key]) =>
+                !server.supportedMethods.includes(key as server.Methods) ||
+                includeEndpoint(path, key.toUpperCase() as Uppercase<server.Methods>)
+            )
+          )
+        ])
+        .filter(([, pathObject]) => server.supportedMethods.some(method => pathObject[method]))
+    )
+  };
 }
 
 export function isReferenceObject(schema: any): schema is oas.ReferenceObject {

--- a/packages/oats/test/include-endpoints.spec.ts
+++ b/packages/oats/test/include-endpoints.spec.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type * as oas from 'openapi3-ts';
+import * as yaml from 'js-yaml';
+import { filterEndpointsInSpec } from '../src/util';
+
+const exampleSpecFile = readFileSync(join(__dirname, './example.yaml'), 'utf8');
+const getExampleSpec = () => yaml.load(exampleSpecFile) as oas.OpenAPIObject;
+
+describe('filterEndpointsInSpec()', () => {
+  it('returns same spec if no includeEndpoints is provided', () => {
+    const resultSpec = filterEndpointsInSpec(getExampleSpec(), { includeEndpoints: undefined });
+
+    expect(resultSpec).toStrictEqual(getExampleSpec());
+  });
+
+  it('throws an error if the included endpoint does not exist', () => {
+    expect(() =>
+      filterEndpointsInSpec(getExampleSpec(), {
+        includeEndpoints: {
+          '/item/{id}': ['POST']
+        }
+      })
+    ).toThrow(
+      new Error(
+        'Cannot include endpoint "POST /item/{id}" - not found in the provided OpenApi spec.'
+      )
+    );
+  });
+
+  it('includes only given methods in the spec', () => {
+    const resultSpec = filterEndpointsInSpec(getExampleSpec(), {
+      includeEndpoints: {
+        '/item/{id}': ['HEAD', 'GET']
+      }
+    });
+    const { paths: originalPaths, ...originalSpec } = getExampleSpec();
+
+    expect(resultSpec).toStrictEqual({
+      ...originalSpec,
+      paths: {
+        '/item/{id}': {
+          head: originalPaths['/item/{id}'].head,
+          get: originalPaths['/item/{id}'].get
+        }
+      }
+    });
+  });
+
+  it('includes endpoints for multiple paths', () => {
+    const resultSpec = filterEndpointsInSpec(getExampleSpec(), {
+      includeEndpoints: {
+        '/item': ['POST'],
+        '/item/{id}': ['DELETE']
+      }
+    });
+    const { paths: originalPaths, ...originalSpec } = getExampleSpec();
+
+    expect(resultSpec).toStrictEqual({
+      ...originalSpec,
+      paths: {
+        '/item': {
+          post: originalPaths['/item'].post
+        },
+        '/item/{id}': {
+          delete: originalPaths['/item/{id}'].delete
+        }
+      }
+    });
+  });
+
+  it('does not mutate the input spec', () => {
+    const inputSpec = getExampleSpec();
+    const resultSpec = filterEndpointsInSpec(inputSpec, {
+      includeEndpoints: {
+        '/item': []
+      }
+    });
+    const originalSpec = getExampleSpec();
+
+    expect(inputSpec).toStrictEqual(originalSpec);
+    expect(resultSpec).toStrictEqual({ ...originalSpec, paths: {} });
+  });
+});


### PR DESCRIPTION
Implements `includeEndpoints` driver option to generate code only for the given endpoints.