### PR TITLE
Fix / Add response headers to nock reply in adapterForServer in oats-nock-adapter

### DIFF
--- a/packages/oats-nock-adapter/src/nock.ts
+++ b/packages/oats-nock-adapter/src/nock.ts
@@ -235,7 +235,8 @@ export class Server<Spec> {
           });
           const status = result.status;
           const responseBody = result.value.value;
-          cb(null, [status, responseBody]);
+          const responseHeaders = result.headers;
+          cb(null, [status, responseBody, responseHeaders]);
         } catch (e: any) {
           cb(e, [400, e.message]);
         }


### PR DESCRIPTION
Fixes the header issue in https://github.com/smartlyio/unity/pull/1484 tests