### PR TITLE
fix: support relative path in playwright adapter

### DIFF
--- a/packages/oats-playwright-adapter/index.ts
+++ b/packages/oats-playwright-adapter/index.ts
@@ -159,19 +159,22 @@ export function create(
     }
     const server = arg.servers[0];
     const requestBody = toRequestBody(arg.body);
-    const url = new URL(server + arg.path);
     const requestContentType = arg.body?.contentType;
+    const searchParams = new URLSearchParams();
 
     Object.entries(arg.query ?? {})
       .filter(([, value]) => !!value)
       .forEach(([key, value]) =>
         Array.isArray(value)
-          ? value.forEach(v => url.searchParams.append(key, `${v}`))
-          : url.searchParams.append(key, `${value}`)
+          ? value.forEach(v => searchParams.append(key, `${v}`))
+          : searchParams.append(key, `${value}`)
       );
 
+    const query = searchParams.toString();
+    const url = `${server}${arg.path}${query ? `?${query}` : ''}`;
+
     const response = await abortable(
-      request.fetch(url.toString(), {
+      request.fetch(url, {
         method: arg.method.toUpperCase(),
         headers: {
           ...(requestContentType ? { 'content-type': requestContentType } : {}),

--- a/packages/oats-playwright-adapter/package.json
+++ b/packages/oats-playwright-adapter/package.json
@@ -33,6 +33,7 @@
     "playwright"
   ],
   "devDependencies": {
+    "@jest/globals": "29.5.0",
     "@smartlyio/oats-runtime": "workspace:^",
     "@types/node": "24.12.4",
     "@typescript-eslint/eslint-plugin": "5.62.0",

--- a/packages/oats-playwright-adapter/test/create.spec.ts
+++ b/packages/oats-playwright-adapter/test/create.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import * as playwrightAdapter from '../index';
+import type { APIRequestContext, APIResponse } from 'playwright';
+import type * as runtime from '@smartlyio/oats-runtime';
+
+function mockResponse(
+  overrides: Partial<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> = {}
+): APIResponse {
+  const status = overrides.status ?? 200;
+  const headers = overrides.headers ?? { 'content-type': 'text/plain' };
+  const body = overrides.body ?? 'ok';
+
+  return {
+    status: () => status,
+    headers: () => headers,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  } as APIResponse;
+}
+
+function mockRequest(): APIRequestContext & { fetch: jest.Mock } {
+  return {
+    fetch: jest.fn(async () => mockResponse())
+  } as unknown as APIRequestContext & { fetch: jest.Mock };
+}
+
+function adapterArg(
+  overrides: Partial<runtime.server.EndpointArg<any, any, any, any>> = {}
+): Parameters<ReturnType<typeof playwrightAdapter.create>>[0] {
+  return {
+    path: '/',
+    method: 'get',
+    servers: ['http://localhost:3000'],
+    headers: undefined,
+    params: undefined,
+    query: undefined,
+    body: undefined,
+    requestContext: { path: overrides.path ?? '/' },
+    ...overrides
+  };
+}
+
+describe('create()', () => {
+  let request: ReturnType<typeof mockRequest>;
+
+  beforeEach(() => {
+    request = mockRequest();
+  });
+
+  it('builds request url from relative server without using URL constructor', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['/creative-templates'],
+        path: '/items'
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith(
+      '/creative-templates/items',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('builds request url from another relative server', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['/matrix'],
+        path: '/entities'
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith('/matrix/entities', expect.any(Object));
+  });
+
+  it('appends query parameters to relative server urls', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['/matrix'],
+        path: '/entities',
+        query: { one: 'the loneliest number' }
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith(
+      '/matrix/entities?one=the+loneliest+number',
+      expect.any(Object)
+    );
+  });
+
+  it('appends array query parameters to relative server urls', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['/matrix'],
+        path: '/entities',
+        query: { numbers: ['one', 'two'] }
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith(
+      '/matrix/entities?numbers=one&numbers=two',
+      expect.any(Object)
+    );
+  });
+
+  it('builds request url from absolute server', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['http://localhost:3000'],
+        path: '/items',
+        query: { filter: 'active' }
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/items?filter=active',
+      expect.any(Object)
+    );
+  });
+
+  it('omits query string when query parameters are empty', async () => {
+    const adapter = playwrightAdapter.create(request);
+
+    await adapter(
+      adapterArg({
+        servers: ['/matrix'],
+        path: '/entities',
+        query: {}
+      })
+    );
+
+    expect(request.fetch).toHaveBeenCalledWith('/matrix/entities', expect.any(Object));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
 
   packages/oats-playwright-adapter:
     devDependencies:
+      '@jest/globals':
+        specifier: 29.5.0
+        version: 29.5.0
       '@smartlyio/oats-runtime':
         specifier: workspace:^
         version: link:../oats-runtime


### PR DESCRIPTION
Currently playwright adapter for oats throws an error if the adapter is configured using relative url (e.g. `/creative-templates` or `/matrix`). In this case it throws an [error](https://github.com/smartlyio/frontend/actions/runs/27412288256/job/81024282009?pr=51076#step:10:720): `TypeError: Invalid URL`.

This PR should fix this problem by using a similar approach as in the axios adapter.

The change was tested locally in frontend repository by manually changing compiled file to use the same code as in the changes ts file.