### PR TITLE
VLCN-4301: Upgrade to pnpm 11.20.0 and add supply-chain hardening

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.16.0
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.16.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 .yalc
 yalc.lock
 yarn.lock
+.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
     "tsconfig-paths": "4.2.0",
     "typescript": "5.7.2"
   },
-  "packageManager": "pnpm@10.16.0"
+  "packageManager": "pnpm@11.20.0",
+  "engines": {
+    "node": ">=22.13",
+    "pnpm": "^11.20.0"
+  }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,15 @@ packages:
   - packages/*
 
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@smartly/*"
+
+# Supply chain hardening (see https://pnpm.io/settings)
+engineStrict: true
+
+# Install/postinstall scripts run only for explicitly allowlisted packages.
+strictDepBuilds: true
+allowBuilds: {}
+
+# Transitive deps must resolve from the registry, not git/tarball URLs.
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary
- Upgrade `packageManager` to pnpm 11.20.0 and declare compatible `engines`.
- Add/fill `pnpm-workspace.yaml` supply-chain protections (`engineStrict`, `minimumReleaseAge`, `strictDepBuilds`/`allowBuilds`, `blockExoticSubdeps`); keep existing age/excludes when present.
- Point CI at Corepack/`packageManager` where hardcoded old pnpm pins existed; ignore `.pnpm-store/`.

## Test plan
- [ ] CI green on this PR
- [x] Local `pnpm install` / supply-chain policy check where credentials allow
