### PR TITLE
VLCN-4301: Disable dependency verification before run

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,9 @@ minimumReleaseAgeExclude:
 # Supply chain hardening (see https://pnpm.io/settings)
 engineStrict: true
 
+# Avoid non-TTY module purge prompts during pnpm runtime dependency checks.
+verifyDepsBeforeRun: false
+
 # Install/postinstall scripts run only for explicitly allowlisted packages.
 strictDepBuilds: true
 allowBuilds: {}


### PR DESCRIPTION
## Summary
- disable pnpm runtime dependency verification for workspace commands
- avoid module purge prompts in non-TTY CI and container environments

## Tests
- `CI=true pnpm install --frozen-lockfile`
- `git diff --check`