### PR TITLE
fix: correct nock adapter repository metadata

### DIFF
--- a/packages/oats-nock-adapter/package.json
+++ b/packages/oats-nock-adapter/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/smartlyio/oats-nock-adapter.git"
+    "url": "https://github.com/smartlyio/oats"
   },
   "peerDependencies": {
     "@smartlyio/oats-runtime": "^6.0.0 || ^7.0.0",


### PR DESCRIPTION
## Summary
- Correct the `repository.url` for `@smartlyio/oats-nock-adapter` to the monorepo URL.

## Root cause
[PR #519](https://github.com/smartlyio/oats/pull/519) changed package publishing from npm token authentication to OIDC trusted publishing.
That enabled npm provenance validation against `repository.url`.
The nock adapter's package-specific URL predated [PR #520](https://github.com/smartlyio/oats/pull/520) and was accepted by token publishing.
PR #520 triggered the first release after PR #519, so it exposed the issue but did not introduce the bad URL.

## Why
The v7.9.0 publish failed for this package because npm trusted publishing rejected its package-specific repository URL. The other v7.9.0 packages were already published, so this fix is released as a patch version.

## Testing
- `git diff --check`
- Parsed the package metadata with Node.js
